### PR TITLE
fix: Fixes issue where `docsig -v` did not print version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased](https://github.com/jshwi/docsig/compare/v0.13.0...HEAD)
 ------------------------------------------------------------------------
+### Fixed
+Fixes issue where `docsig -v` did not print version
 
 [0.13.0](https://github.com/jshwi/docsig/releases/tag/v0.13.0) - 2022-07-02
 ------------------------------------------------------------------------

--- a/docsig/_config.py
+++ b/docsig/_config.py
@@ -91,6 +91,6 @@ class Parser(_ArgumentParser):
 
     @staticmethod
     def _version_request() -> None:
-        if len(_sys.argv) > 1 and _sys.argv[1] == "--version":
+        if len(_sys.argv) > 1 and _sys.argv[1] in ("-v", "--version"):
             print(__version__)
             _sys.exit(0)

--- a/tests/_test.py
+++ b/tests/_test.py
@@ -25,10 +25,12 @@ from . import (
 from ._utils import NoColorCapsys, errors, hints
 
 
+@pytest.mark.parametrize("arg", ("-v", "--version"))
 def test_print_version(
     monkeypatch: pytest.MonkeyPatch,
     main: MockMainType,
     nocolorcapsys: NoColorCapsys,
+    arg: str,
 ) -> None:
     """Test printing of version on commandline.
 
@@ -39,7 +41,7 @@ def test_print_version(
     """
     monkeypatch.setattr("docsig._config.__version__", "1.0.0")
     with pytest.raises(SystemExit):
-        main("--version")
+        main(arg)
 
     assert nocolorcapsys.stdout().strip() == "1.0.0"
 


### PR DESCRIPTION
Both `-v` and `--version` now print version