### PR TITLE
fix: Fix incorrect `pre-commit` documentation (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased](https://github.com/jshwi/docsig/compare/v0.33.0...HEAD)
 ------------------------------------------------------------------------
+### Fixed
+- Fix incorrect `pre-commit` documentation
 
 [0.33.0](https://github.com/jshwi/docsig/releases/tag/v0.33.0) - 2022-12-21
 ------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -203,9 +203,7 @@ It can be added to your .pre-commit-config.yaml as follows:
         rev: v0.30.0
         hooks:
           - id: docsig
-            name: docsig
-            entry: docsig
-            language: system
+            language: python
             types: [python]
             args:
               - "--check-class"


### PR DESCRIPTION
Example .pre-commit-hooks.yaml was based on `pylint`, a local install