### PR TITLE
change: remove default value for positional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased](https://github.com/jshwi/docsig/compare/v0.34.2...HEAD)
 ------------------------------------------------------------------------
+### Changed
+- remove default value for positional arguments
 
 [0.34.2](https://github.com/jshwi/docsig/releases/tag/v0.34.2) - 2023-08-08
 ------------------------------------------------------------------------

--- a/docsig/_config.py
+++ b/docsig/_config.py
@@ -31,11 +31,10 @@ class Parser(_ArgumentParser):
     def _add_arguments(self) -> None:
         self.add_argument(
             "path",
-            nargs="*",
+            nargs="+",
             action="store",
             type=_Path,
-            default=[_Path(".")],
-            help="directories or files to check (default: .)",
+            help="directories or files to check",
         )
         self.add_argument(
             "-c",

--- a/tests/_test.py
+++ b/tests/_test.py
@@ -78,7 +78,7 @@ def test_exit_status(
     :param template: Contents to write to file.
     """
     init_file(template)
-    assert main(*CHECK_ARGS) == int(name.startswith(FAIL))
+    assert main(".", *CHECK_ARGS) == int(name.startswith(FAIL))
 
 
 @pytest.mark.parametrize(
@@ -121,7 +121,7 @@ def test_stdout(
     :param expected: Expected output.
     """
     init_file(template)
-    main(*CHECK_ARGS)
+    main(".", *CHECK_ARGS)
     std = capsys.readouterr()
     assert expected
     assert expected in std.out
@@ -159,7 +159,7 @@ def test_error_codes(
     """
     init_file(template)
     messages = [i for i in errors if getattr(docsig.messages, i) != expected]
-    main()
+    main(".")
     std = capsys.readouterr()
     assert std.out.count(expected) == 1
     assert not any(getattr(docsig.messages, i) in std.out for i in messages)
@@ -193,7 +193,7 @@ def test_multiple(
     :param expected: Expected result.
     """
     init_file(templates.registered.getgroup(MULTI)[0].template)
-    main()
+    main(".")
     std = capsys.readouterr()
     assert expected in std.out
 
@@ -232,7 +232,7 @@ def test_disable_rule(
     :param template: Contents to write to file.
     """
     init_file(template)
-    assert main(long.disable, name.replace("-", "").upper()[1:5]) == 0
+    assert main(".", long.disable, name.replace("-", "").upper()[1:5]) == 0
 
 
 @pytest.mark.parametrize(
@@ -257,7 +257,7 @@ def test_summary(
     :param template: Contents to write to file.
     """
     init_file(template.template)
-    main(*CHECK_ARGS, long.summary)
+    main(".", *CHECK_ARGS, long.summary)
     std = capsys.readouterr()
     assert CHECK not in std.out
     assert CROSS not in std.out
@@ -285,7 +285,7 @@ def test_no_stdout(
     :param template: String data.
     """
     init_file(template.template)
-    main(*CHECK_ARGS)
+    main(".", *CHECK_ARGS)
     std = capsys.readouterr()
     assert not std.out
 
@@ -338,7 +338,7 @@ def test_ignore_no_params(
         "Returns:",
     )
     init_file(template)
-    returncode = main(*CHECK_ARGS, long.ignore_no_params)
+    returncode = main(".", *CHECK_ARGS, long.ignore_no_params)
     std = capsys.readouterr()
 
     # expected result one of the messages indicating missing params
@@ -378,7 +378,7 @@ def test_no_check_property_returns_flag(
     :param template: Contents to write to file.
     """
     init_file(template.template)
-    main()
+    main(".")
     std = capsys.readouterr()
     assert docsig.messages.E108 in std.out
     assert docsig.messages.H101 in std.out
@@ -489,7 +489,7 @@ def test_no_flag(
     :param template: Contents to write to file.
     """
     init_file(template.template)
-    assert main() == 0
+    assert main(".") == 0
 
 
 @pytest.mark.parametrize(
@@ -518,7 +518,7 @@ def test_single_flag(
     :param template: Contents to write to file.
     """
     init_file(template)
-    assert main(f"--check-{name.split('-')[1]}") == 1
+    assert main(".", f"--check-{name.split('-')[1]}") == 1
 
 
 @pytest.mark.parametrize(
@@ -553,7 +553,7 @@ def test_string_argument(
     :param template: String data.
     :param expected: Expected output.
     """
-    assert main(*CHECK_ARGS, long.string, template) == int(
+    assert main(".", *CHECK_ARGS, long.string, template) == int(
         name.startswith(FAIL)
     )
     std = capsys.readouterr()

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -104,7 +104,7 @@ def test_lineno(
     init_file(
         templates.registered.getbyname("m-fail-s").template  # type: ignore
     )
-    main()
+    main(".")
     std = capsys.readouterr()
     assert "module/file.py:2" in std.out
     assert "module/file.py:11" in std.out


### PR DESCRIPTION
defaulting to "$PWD" is confusing if run in a location with lots of files an example of this is when run in "$HOME" and the program appears to hang it is likely expected behaviour to see help for args that are required