### PR TITLE
doc: remove double spaces in docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ pygments_style = "monokai"
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
+# The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
 html_theme = "sphinx_immaterial"

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -151,7 +151,7 @@ pass.
 
 Test that all tests emit no output.
 
-Only test templates prefixed with P are collected for  this test,
+Only test templates prefixed with P are collected for this test,
 and all tests should pass.
 
 

--- a/tests/_test.py
+++ b/tests/_test.py
@@ -274,7 +274,7 @@ def test_no_stdout(
 ) -> None:
     """Test that all tests emit no output.
 
-    Only test templates prefixed with `P` are collected for  this test,
+    Only test templates prefixed with `P` are collected for this test,
     and all tests should pass.
 
     :param capsys: Capture sys out.

--- a/tests/disable_test.py
+++ b/tests/disable_test.py
@@ -1285,7 +1285,7 @@ def test_module_enables(
     init_file: InitFileFixtureType,
     main: MockMainType,
 ) -> None:
-    """Test individual  checks.
+    """Test individual checks.
 
     :param capsys: Capture sys out.
     :param init_file: Initialize a test file.


### PR DESCRIPTION
Hi,

While working on #213, I noticed a double whitespace in `tests/_test.py` - thought I'd open a PR to fix that, and then I also searched the whole codebase for matches on `\S  [^#\s]` and addressed those too (and also `\S +[^#\s]` but that only gave 'false positives' beyond the 'exactly 2 spaces' regex).