### PR TITLE
fix: only check params for incorrect-indent (#427)

### DIFF
--- a/changelog/427.fix.md
+++ b/changelog/427.fix.md
@@ -1,0 +1,1 @@
+only check params for incorrect-indent

--- a/docs/usage/message-control.rst
+++ b/docs/usage/message-control.rst
@@ -42,10 +42,10 @@ Commandline
     ... def func(param, param2, param3, param4) -> int:
     ...     """Desc.
     ...
-    ...     :param param1: About param1.
-    ...     :param param2:A.
-    ...     :param param3:
-    ...      """
+    ...      :param param1: About param1.
+    ...      :param param2:A.
+    ...      :param param3:
+    ...     """
     ... '''
 
 .. code-block:: python
@@ -100,10 +100,10 @@ Directives
     ... ) -> int:
     ...     """Desc.
     ...
-    ...     :param param1: About param1.
-    ...     :param param2:A.
-    ...     :param param3:
-    ...      """
+    ...      :param param1: About param1.
+    ...      :param param2:A.
+    ...      :param param3:
+    ...     """
     ... '''
 
 .. code-block:: python

--- a/docs/usage/message-control/commandline.rst
+++ b/docs/usage/message-control/commandline.rst
@@ -11,10 +11,10 @@ More on commandline
     ... def func(param, param2, param3, param4) -> int:
     ...     """Desc.
     ...
-    ...     :param param1: About param1.
-    ...     :param param2:A.
-    ...     :param param3:
-    ...      """
+    ...      :param param1: About param1.
+    ...      :param param2:A.
+    ...      :param param3:
+    ...     """
     ... '''
 
 .. code-block:: python
@@ -143,10 +143,10 @@ disable everything else
     ... ) -> int:
     ...     """Desc.
     ...
-    ...     :param param1: About param1.
-    ...     :param param2:A.
-    ...     :param param3:
-    ...      """
+    ...      :param param1: About param1.
+    ...      :param param2:A.
+    ...      :param param3:
+    ...     """
     ... '''
 
 .. code-block:: python

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -298,11 +298,14 @@ class Docstring(_Stub):
     def _indent_anomaly(string: str) -> bool:
         leading_spaces = []
         for line in string.splitlines():
-            match = _re.match(r"^\s*", line)
-            if match is not None:
-                spaces = len(match.group())
-                if spaces > 0:
-                    leading_spaces.append(spaces)
+            # only check params
+            # description or anything else is out of scope
+            if line.lstrip().startswith(":"):
+                match = _re.match(r"^\s*", line)
+                if match is not None:
+                    spaces = len(match.group())
+                    if spaces > 0:
+                        leading_spaces.append(spaces)
 
         # look for spaces in odd intervals
         return bool(any(i % 2 != 0 for i in leading_spaces))


### PR DESCRIPTION
Description or anything else is out of scope