### PR TITLE
description missing and description syntax error #461

### DIFF
--- a/changelog/461.fix.md
+++ b/changelog/461.fix.md
@@ -1,0 +1,1 @@
+fix missing description with multiple args

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -15,7 +15,7 @@ import astroid as _ast
 import sphinx.ext.napoleon as _s
 
 # no function will accidentally have this name
-UNNAMED = -1000
+UNNAMED = "-1000"
 
 # an example of valid parameter description
 VALID_DESCRIPTION = " A valid description."

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -397,3 +397,32 @@ def function(param1, param2, param3) -> None:
     flake8(".", "--sig-check-class", "--sig-check-class-constructor")
     std = capsys.readouterr()
     assert docsig.messages.E[5].description in std.out
+
+
+def test_description_missing_and_description_syntax_error_461(
+    capsys: pytest.CaptureFixture,
+    main: MockMainType,
+    init_file: InitFileFixtureType,
+) -> None:
+    """Test description missing raised with other description.
+
+    Other description would cause a syntax in description error if it
+    spanned over multiple lines.
+
+    :param capsys: Capture sys out.
+    :param main: Mock ``main`` function.
+    :param init_file: Initialize a test file.
+    """
+    template = '''
+def function(param1, param2) -> None:
+    """
+
+    :param param1:
+    :param param2: This one does have a description however
+        and continues on the next line.
+    """
+'''
+    init_file(template)
+    main(".", test_flake8=False)
+    std = capsys.readouterr()
+    assert docsig.messages.E[301].description in std.out


### PR DESCRIPTION
If one arg was missing, and another description spanned over multiple lines, this would result in a description syntax error (which is not valid for either), and not just the one description missing violation