### PR TITLE
Skip nonalpha chars

### DIFF
--- a/docsig/_report.py
+++ b/docsig/_report.py
@@ -219,9 +219,9 @@ class Failure(_t.List[Failed]):
             # bad-closing-token
             self._add(_E[304], token=doc.closing_token, hint=True)
         if doc.description is not None and not all(
-            i.strip()[0].isupper()
+            stripped[0].isupper()
             for i in _sentence_tokenizer(doc.description)
-            if i and not any(i.startswith(x) for x in (":", ".", "`"))
+            if i and (stripped := i.strip())[0].isalpha()
         ):
             # description is not capitalized
             self._add(_E[305])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ fail_under = 100
 
 [tool.coverage.run]
 omit = [
+  "*/sitecustomize.py",
   "docs/conf.py",
   "docsig/__main__.py",
   "whitelist.py"

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -756,6 +756,30 @@ def function(a) -> None:
     assert E[305].ref in std.out
 
 
+def test_enforce_capitalisation_should_not_after_nonalpha(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Test enforce capitalisation after nonalpha character.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialise a test file.
+    :param main: Patch package entry point.
+    """
+    template = '''
+def function(a=False) -> None:
+    """Docstring summary.
+
+    :param a: (Optional) Description of a.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[305].ref not in std.out
+
+
 def test_enforce_capitalisation_should_not_591(
     init_file: FixtureInitFile,
     main: FixtureMain,


### PR DESCRIPTION
Updated SIG305 to only check first letter capitalization on alphabetic characters. This allows patterns such as the one below:

```
def function(a=False) -> None:
    """Docstring summary.

    :param a: (Optional) Description of a.
```