### PR TITLE
fix: evaluate docstring when description is missing (#922)

### DIFF
--- a/changelog/922.fix.md
+++ b/changelog/922.fix.md
@@ -1,0 +1,1 @@
+evaluate docstring when description is missing

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -7,8 +7,8 @@ Stub types for parsed docstrings and signatures.
 
 from __future__ import annotations as _
 
+import inspect as _inspect
 import re as _re
-import textwrap as _textwrap
 import typing as _t
 from collections import Counter as _Counter
 from enum import Enum as _Enum
@@ -333,9 +333,7 @@ class Docstring(_Stub):
             _s.NumpyDocstring(  # type: ignore
                 str(
                     _s.GoogleDocstring(  # type: ignore
-                        _textwrap.dedent(
-                            "\n".join(string.splitlines()[1:]),
-                        ).replace("*", ""),
+                        _inspect.cleandoc(string).replace("*", ""),
                     ),
                 ),
             ),

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -1734,3 +1734,32 @@ def my_function():  # docsig: disable=SIG501
     main(".")
     std = capsys.readouterr()
     assert E[501].ref not in std.out
+
+
+def test_fix_normalize_docstring_keeps_first_line(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Keep a leading Numpy section header when normalizing.
+
+    A docstring may start with ``Returns`` (no summary line). Dropping
+    the first line removes that header and falsely reports a missing
+    return.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function() -> str:
+    """Returns
+    -------
+    str
+        The name.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[503].ref not in std.out


### PR DESCRIPTION
Closes #922

When a docstring has no summary/description line and begins directly with a section header, `_normalize_docstring` was using `splitlines()[1:]` to skip the summary. With no summary present, this dropped the section header instead, causing it to go unrecognised.

Fix: replace `splitlines()[1:]` with `inspect.cleandoc`, which normalises indentation without discarding any lines.