### PR TITLE
fix: false missing params when rst has returns heading (#924)

### DIFF
--- a/changelog/924.fix.md
+++ b/changelog/924.fix.md
@@ -1,0 +1,1 @@
+false missing params when rst has returns heading

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -326,18 +326,43 @@ class Docstring(_Stub):
         return False
 
     @staticmethod
+    def _docstring_style(string: str) -> str:
+        # prefer existing rst fields over napoleon section headers
+        if _re.search(r"^:\w+", string, _re.MULTILINE):
+            return "rst"
+
+        if _re.search(
+            r"^(Parameters|Other Parameters|Returns|Yields|Raises|"
+            r"See Also|Notes|Examples|Attributes|Methods)\n"
+            r"\s*-{3,}\s*$",
+            string,
+            _re.MULTILINE,
+        ):
+            return "numpy"
+
+        if _re.search(
+            r"^(Args|Arguments|Parameters|Returns|Yields|Raises|"
+            r"Attributes|Example|Examples):\s*$",
+            string,
+            _re.MULTILINE,
+        ):
+            return "google"
+
+        return "rst"
+
+    @staticmethod
     def _normalize_docstring(string: str) -> str:
-        # convert Google and numpy style docstrings to parse docstrings
-        # as restructured text
-        return str(
-            _s.NumpyDocstring(  # type: ignore
-                str(
-                    _s.GoogleDocstring(  # type: ignore
-                        _inspect.cleandoc(string),
-                    ),
-                ),
-            ),
-        )
+        # convert Google or numpy style to rst when detected
+        # leave rst (including field lists) unchanged
+        string = _inspect.cleandoc(string)
+        style = Docstring._docstring_style(string)
+        if style == "google":
+            return str(_s.GoogleDocstring(string))  # type: ignore
+
+        if style == "numpy":
+            return str(_s.NumpyDocstring(string))  # type: ignore
+
+        return string
 
     def __init__(
         self,

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -1763,3 +1763,37 @@ def function() -> str:
     assert main(".") == 0
     std = capsys.readouterr()
     assert E[503].ref not in std.out
+
+
+def test_fix_normalize_skips_napoleon_when_rst_fields_present(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Leave RST field lists alone when Napoleon would mangle them.
+
+    An RST docstring may use an underlined Returns heading for prose
+    and still document params with sphinx field lists. Always running
+    Numpy conversion rewrites those fields and falsely reports missing
+    parameters.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(a) -> str:
+    """Fetch the record.
+
+    Returns
+    -------
+    Always a string for callers.
+
+    :param a: Record id.
+    :returns: The record.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[203].ref not in std.out


### PR DESCRIPTION
Closes #924

An RST docstring that uses an underlined `Returns` heading for prose while still documenting params with sphinx field lists falsely reported SIG203 (parameters missing).

**Root cause:** `_normalize_docstring` unconditionally ran Napoleon (NumPy then Google) conversion on all docstrings. An RST docstring with a `Returns\n-------` section looks like NumPy to Napoleon, which rewrites the RST field lists and causes the params to go unrecognised.

Fix: detect the docstring style first and only apply Napoleon conversion when the style is actually Google or NumPy. RST docstrings (identified by the presence of `:field:` syntax) are left unchanged.