### PR TITLE
fix: false positives for rst fields in description prose (#935)

### DIFF
--- a/changelog/935.fix.md
+++ b/changelog/935.fix.md
@@ -1,0 +1,1 @@
+false positives for rst fields in description prose

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -382,9 +382,9 @@ class Docstring(_Stub):
         indent_anomaly = cls._indent_anomaly(node.value)
         string = cls._normalize_docstring(node.value)
         match = _re.search(
-            r":(?:returns?|yields?):\s*(.*)",
+            r"^[ \t]*:(?:returns?|yields?):\s*(.*)",
             string,
-            _re.IGNORECASE,
+            _re.IGNORECASE | _re.MULTILINE,
         )
         returns = _Return(
             bool(match),
@@ -394,12 +394,13 @@ class Docstring(_Stub):
         # the suggestion is broken
         # noinspection RegExpSingleCharAlternation
         for match in _re.findall(
-            r":((?:\\?\*){0,2}[\w]+"
+            r"^[ \t]*:((?:\\?\*){0,2}[\w]+"
             r"(?:\s+(?:\\?\*){0,2}[\w]+|"
             r"\s\|\s(?:\\?\*){0,2}[\w]+)*)"
             r"([^\w\s\\*])"
-            r"((?:.|\n)*?)(?=\n:|$)",
+            r"((?:.|\n)*?)(?=\n[ \t]*:|\Z)",
             string,
+            _re.MULTILINE,
         ):
             if match:
                 kinds = match[0].split()

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -1797,3 +1797,59 @@ def function(a) -> str:
     assert main(".") == 0
     std = capsys.readouterr()
     assert E[203].ref not in std.out
+
+
+def test_fix_rst_field_in_prose_does_not_trigger_return_check(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """RST field syntax in description prose must not flag a return.
+
+    A description mentioning ``:returns:`` mid-sentence is prose, not a
+    return declaration, and must not trigger return-documented-for-none.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(a) -> None:
+    """Docstring summary.
+
+    This calls foo which :returns: a value.
+
+    :param a: A parameter.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[502].ref not in std.out
+
+
+def test_fix_rst_field_in_prose_does_not_trigger_param_check(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """RST field syntax in description prose must not flag a parameter.
+
+    A description mentioning ``:param x:`` mid-sentence is prose, not a
+    parameter declaration, and must not trigger params-do-not-exist.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function() -> None:
+    """Docstring summary.
+
+    Pass :param x: to configure the behavior.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[202].ref not in std.out


### PR DESCRIPTION
Closes #935

RST field syntax mentioned mid-sentence in description prose was parsed as a real field declaration, causing false SIG502 (return documented for None) and SIG202 (params do not exist).

**Root cause:** The regexes that extract `:returns:` and `:param x:` fields from the docstring matched anywhere in the string rather than only at the start of a line, so field-like syntax embedded in prose was treated as a declaration.

Fix: anchor both field regexes to the start of a line (with optional leading whitespace) using multiline mode, so only genuine field-list entries are parsed as fields.