### PR TITLE
fix: false SIG501 for property setter/deleter methods (#936)

### DIFF
--- a/changelog/936.fix.md
+++ b/changelog/936.fix.md
@@ -1,0 +1,1 @@
+false SIG501 for property setter/deleter methods

--- a/docsig/_module.py
+++ b/docsig/_module.py
@@ -282,8 +282,8 @@ class Function(Parent):  # pylint: disable=too-many-instance-attributes
 
     @property
     def isproperty(self) -> bool:
-        """Whether this function is a property."""
-        valid_properties = "property", "cached_property"
+        """Whether this function is a property or property method."""
+        valid_properties = "property", "cached_property", "setter", "deleter"
         return self.ismethod and any(
             self._decorated_with(i) for i in valid_properties
         )

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -1853,3 +1853,70 @@ def function() -> None:
     assert main(".") == 0
     std = capsys.readouterr()
     assert E[202].ref not in std.out
+
+
+def test_fix_setter_does_not_trigger_return_check(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Property setter is exempt from return documentation checks.
+
+    A setter decorated with ``@<name>.setter`` never returns a value
+    and must not trigger confirm-return-needed.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+class MyClass:
+    @property
+    def value(self):
+        """Get the value."""
+        return self._value
+
+    @value.setter
+    def value(self, val):
+        """Set the value.
+
+        :param val: New value.
+        """
+        self._value = val
+'''
+    init_file(template)
+    assert main(".", "--check-class") == 0
+    std = capsys.readouterr()
+    assert E[501].ref not in std.out
+
+
+def test_fix_deleter_does_not_trigger_return_check(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Property deleter is exempt from return documentation checks.
+
+    A deleter decorated with ``@<name>.deleter`` never returns a value
+    and must not trigger confirm-return-needed.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+class MyClass:
+    @property
+    def value(self):
+        """Get the value."""
+        return self._value
+
+    @value.deleter
+    def value(self):
+        """Delete the value."""
+        del self._value
+'''
+    init_file(template)
+    assert main(".", "--check-class") == 0
+    std = capsys.readouterr()
+    assert E[501].ref not in std.out


### PR DESCRIPTION
Closes #936

Unannotated property setter and deleter methods falsely reported SIG501 (cannot determine whether a return statement should exist), even though they never return a value.

**Root cause:** `Function.isproperty` only recognised the `property` and `cached_property` decorators, so methods decorated with `@<name>.setter` or `@<name>.deleter` were not treated as property methods and fell through to the return-annotation check.

Fix: add `setter` and `deleter` to the decorators recognised by `isproperty`, exempting them like getters.