### PR TITLE
fix: treat NoReturn/Never annotations as non-returning (#937)

### DIFF
--- a/changelog/937.fix.md
+++ b/changelog/937.fix.md
@@ -1,0 +1,1 @@
+treat NoReturn/Never annotations as non-returning

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -42,6 +42,18 @@ class RetType(_Enum):
         if isinstance(returns, _ast.nodes.Const) and returns.value is None:
             return cls.NONE
 
+        # NoReturn / Never mean the function never returns a value, so
+        # treat them the same as -> None for documentation purposes
+        _no_return = {"NoReturn", "Never"}
+        if isinstance(returns, _ast.nodes.Name) and returns.name in _no_return:
+            return cls.NONE
+
+        if (
+            isinstance(returns, _ast.nodes.Attribute)
+            and returns.attrname in _no_return
+        ):
+            return cls.NONE
+
         if isinstance(
             returns,
             (

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -1920,3 +1920,39 @@ class MyClass:
     assert main(".", "--check-class") == 0
     std = capsys.readouterr()
     assert E[501].ref not in std.out
+
+
+def test_fix_noreturn_annotation_does_not_require_return_documentation(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """NoReturn and Never annotations suppress the return-missing check.
+
+    A function annotated ``-> NoReturn`` or ``-> Never`` never returns a
+    value, so requiring a ``:return:`` entry in its docstring is wrong.
+    The fix treats these annotations as equivalent to ``-> None`` for
+    documentation purposes, preventing SIG503.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+import typing
+from typing import NoReturn, Never
+def crash() -> NoReturn:
+    """Always raises."""
+    raise RuntimeError()
+def loop() -> Never:
+    """Loops forever."""
+    while True:
+        pass
+def also_crash() -> typing.NoReturn:
+    """Also always raises."""
+    raise RuntimeError()
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[503].ref not in std.out


### PR DESCRIPTION
Closes #937

A function annotated `-> NoReturn` or `-> Never` never returns a value, yet docsig reported SIG503 (return missing from docstring) when the docstring had no `:return:` entry.

**Root cause:** Return-type classification only treated a literal `-> None` as non-returning, so `NoReturn` and `Never` (bare or as `typing.NoReturn`) were classified as returning types requiring return documentation.

Fix: classify `NoReturn` and `Never` annotations (both bare names and attribute access like `typing.NoReturn`) the same as `-> None` for documentation purposes.