### PR TITLE
fix: stop SIG306 false positive on ! or ? sentence endings (#947)

### DIFF
--- a/changelog/947.fix.md
+++ b/changelog/947.fix.md
@@ -1,0 +1,1 @@
+stop SIG306 false positive on ! or ? sentence endings

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -237,6 +237,8 @@ class FunctionChecker:  # pylint: disable=too-few-public-methods
             not in (
                 "`",
                 ".",
+                "!",
+                "?",
             )
         ):
             self._add(_E[306])

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -1956,3 +1956,57 @@ def also_crash() -> typing.NoReturn:
     assert main(".") == 0
     std = capsys.readouterr()
     assert E[503].ref not in std.out
+
+
+def test_fix_allow_exclamation_mark_as_sentence_ending(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Allow exclamation mark as a valid sentence ending.
+
+    A description ending with ``!`` is a complete sentence and must not
+    trigger description-missing-period.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(a) -> None:
+    """Docstring summary.
+
+    :param a: Description of a!
+    """
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[306].ref not in std.out
+
+
+def test_fix_allow_question_mark_as_sentence_ending(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Allow question mark as a valid sentence ending.
+
+    A description ending with ``?`` is a complete sentence and must not
+    trigger description-missing-period.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(a) -> None:
+    """Docstring summary.
+
+    :param a: Is this optional?
+    """
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[306].ref not in std.out


### PR DESCRIPTION
Closes #947

A parameter description ending with `!` or `?` is a complete sentence and should not trigger SIG306 (description-missing-period). Previously only `.` was accepted as a valid sentence ending.

Adds `!` and `?` to the accepted sentence-ending characters, with regression tests for both.