### PR TITLE
fix: false SIG503 when rtype is used as return documentation (#949)

### DIFF
--- a/changelog/949.fix.md
+++ b/changelog/949.fix.md
@@ -1,0 +1,1 @@
+false SIG503 when rtype is used as return documentation

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -394,7 +394,7 @@ class Docstring(_Stub):
         indent_anomaly = cls._indent_anomaly(node.value)
         string = cls._normalize_docstring(node.value)
         match = _re.search(
-            r"^[ \t]*:(?:returns?|yields?):\s*(.*)",
+            r"^[ \t]*:(?:returns?|yields?|rtype):\s*(.*)",
             string,
             _re.IGNORECASE | _re.MULTILINE,
         )

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2010,3 +2010,32 @@ def function(a) -> None:
     assert main(".") == 0
     std = capsys.readouterr()
     assert E[306].ref not in std.out
+
+
+def test_fix_allow_rtype_as_return_documentation(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Allow :rtype: directive as valid return documentation.
+
+    A docstring using :rtype: to annotate the return type is valid RST
+    and must not trigger return-missing.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(a) -> str:
+    """Docstring summary.
+
+    :param a: A parameter.
+    :rtype: str
+    """
+    return str(a)
+'''
+    init_file(template)
+    assert main(".") == 0
+    std = capsys.readouterr()
+    assert E[503].ref not in std.out


### PR DESCRIPTION
Closes #949

A docstring that annotates its return type with the `:rtype:` directive is valid reStructuredText and should not trigger SIG503 (return-missing). Previously only `:returns:`/`:yields:` were recognised as return documentation.

Adds `rtype` to the return-documentation regex, with a regression test.