### PR TITLE
fix: reduce each duplicate parameter group to one copy (#951)

### DIFF
--- a/changelog/951.fix.md
+++ b/changelog/951.fix.md
@@ -1,0 +1,1 @@
+reduce each duplicate parameter group to one copy

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -171,15 +171,17 @@ class FunctionChecker:  # pylint: disable=too-few-public-methods
 
     def _sig2xx_signature(self) -> None:
         if self._func.docstring.args.duplicated:
-            # pop the duplicates so that they are considered a single
-            # parameter, that way there are no assumptions that the
-            # parameters must be out of order
-            for count, arg in enumerate(self._func.docstring.args):
-                if (
-                    arg in self._func.docstring.args.duplicates
-                    and self._func.docstring.args.count(arg) > 1
-                ):
-                    self._func.docstring.args.pop(count)
+            # reduce each duplicate group to one representative without
+            # mutating the list during iteration (which skips items)
+            seen: set[str | None] = set()
+            deduped: list[_Param] = []
+            for arg in self._func.docstring.args:
+                if arg.name not in seen:
+                    seen.add(arg.name)
+                    deduped.append(arg)
+
+            list.clear(self._func.docstring.args)
+            list.extend(self._func.docstring.args, deduped)
 
             # duplicate-params-found
             self._add(_E[201])

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -179,7 +179,6 @@ class Params(list[Param]):
     def __init__(self, ignore: _Ignore) -> None:
         super().__init__()
         self._ignore = ignore
-        self._duplicates: list[Param] = []
 
     def append(self, value: Param) -> None:
         if not value.isprotected and any(
@@ -219,20 +218,7 @@ class Params(list[Param]):
 
         Only names are compared; descriptions are ignored.
         """
-        for k, v in _Counter(i.name for i in self).items():
-            if v > 1:
-                for i in self:
-                    if i.name == k:
-                        # record the duplicates for later analysis
-                        self._duplicates.append(i)
-                        return True
-
-        return False
-
-    @property
-    def duplicates(self) -> list[Param]:
-        """Params that share a name."""
-        return self._duplicates
+        return any(v > 1 for v in _Counter(i.name for i in self).values())
 
 
 class _Stub:

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2039,3 +2039,39 @@ def function(a) -> str:
     assert main(".") == 0
     std = capsys.readouterr()
     assert E[503].ref not in std.out
+
+
+def test_fix_duplicate_dedup_with_multiple_groups_no_spurious_errors(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Deduplication of two groups with unequal counts leaves no extras.
+
+    When two different parameter names are each duplicated, but the
+    first name appears more times than the second, the old pop-during-
+    iteration loop would skip items and leave extra copies behind.
+    Those extras then caused spurious SIG4xx ordering errors.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def func(y, x):
+    """Function.
+
+    :param y: Description.
+    :param x: Description.
+    :param y: Description.
+    :param x: Description.
+    :param y: Description.
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[201].ref in std.out
+    assert E[402].ref not in std.out
+    assert E[403].ref not in std.out
+    assert E[404].ref not in std.out


### PR DESCRIPTION
Closes #951

The duplicate-parameter deduplication popped items from the docstring args list while iterating over it. Mutating the list during iteration skips elements, so when two parameter names were each duplicated an unequal number of times, extra copies were left behind and triggered spurious SIG4xx ordering errors.

Replaces the pop-during-iteration loop with a pass that builds a deduplicated list (one representative per name) and swaps it in, and drops the now-unused `Params.duplicates` machinery. Adds a regression test asserting only SIG201 fires (no SIG402/403/404).