### PR TITLE
fix: false positive SIG305 for abbreviations after sentence end (#957)

### DIFF
--- a/changelog/957.fix.md
+++ b/changelog/957.fix.md
@@ -1,0 +1,1 @@
+false positive SIG305 for abbreviations after sentence end

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -20,6 +20,7 @@ from ._stub import VALID_DESCRIPTION as _VALID_DESCRIPTION
 from ._stub import Param as _Param
 from ._stub import Params as _Params
 from ._stub import RetType as _RetType
+from ._utils import SENTENCE_ABBREVIATIONS as _SENTENCE_ABBREVIATIONS
 from ._utils import almost_equal as _almost_equal
 from ._utils import sentence_tokenizer as _sentence_tokenizer
 from .messages import E as _E
@@ -247,7 +248,11 @@ class FunctionChecker:  # pylint: disable=too-few-public-methods
         if doc_description is not None and not all(
             stripped[0].isupper()
             for i in _sentence_tokenizer(doc_description)
-            if i and (stripped := i.strip())[0].isalpha()
+            if (
+                i
+                and (stripped := i.strip())[0].isalpha()
+                and stripped.lower().split()[0] not in _SENTENCE_ABBREVIATIONS
+            )
         ):
             # description is not capitalized
             self._add(_E[305])

--- a/docsig/_utils.py
+++ b/docsig/_utils.py
@@ -58,6 +58,11 @@ def print_checks() -> None:
         print(msg.fstring(_TEMPLATE))
 
 
+SENTENCE_ABBREVIATIONS = frozenset(
+    {"e.g.", "i.e.", "mr.", "dr.", "vs.", "etc.", "u.s."},
+)
+
+
 def sentence_tokenizer(text: str) -> list[str]:
     """Split text on sentence boundaries, skipping common abbreviations.
 
@@ -67,7 +72,7 @@ def sentence_tokenizer(text: str) -> list[str]:
     :param text: Input string.
     :return: Non-overlapping sentence strings in order.
     """
-    abbreviations = {"e.g.", "i.e.", "mr.", "dr.", "vs.", "etc.", "u.s."}
+    abbreviations = SENTENCE_ABBREVIATIONS
     result = []
     start = 0
 

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2125,3 +2125,33 @@ def func(x) -> None:
     main(".")
     std = capsys.readouterr()
     assert E[306].ref not in std.out
+
+
+def test_fix_abbreviation_after_sentence_does_not_trigger_sig305(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Known abbreviations starting a sentence fragment do not fire SIG305.
+
+    sentence_tokenizer does not split on 'e.g.' or 'i.e.', but after a
+    previous sentence split, those abbreviations can appear at the start
+    of the remaining fragment.  SIG305 must not fire for such fragments
+    because the lowercase letter belongs to the abbreviation, not to a
+    genuine uncapitalized sentence start.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def func(x) -> None:
+    """Summary.
+
+    :param x: Some config value. e.g. use 42 for normal mode.
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[305].ref not in std.out


### PR DESCRIPTION
Closes #957

SIG305 no longer fires when a sentence fragment in a parameter description begins with a known abbreviation such as `e.g.` or `i.e.`. The lowercase letter belongs to the abbreviation, not to a genuine uncapitalized sentence start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)