### PR TITLE
fix: false positive SIG305 for parenthesized abbreviations (#959)

### DIFF
--- a/changelog/959.fix.md
+++ b/changelog/959.fix.md
@@ -1,0 +1,1 @@
+false positive SIG305 for parenthesized abbreviations

--- a/docsig/_utils.py
+++ b/docsig/_utils.py
@@ -75,10 +75,12 @@ def sentence_tokenizer(text: str) -> list[str]:
     result = []
     start = 0
 
-    for match in _re.finditer(r"[.!?]\s+", text):
+    for match in _re.finditer(r"(?<!\.)[.!?]\s+", text):
         end = match.end()
         candidate = text[start:end].strip()
-        last_word = candidate.lower().split()[-1]
+        raw_last = candidate.lower().split()[-1]
+        # strip leading punctuation so "(e.g." matches "e.g."
+        last_word = _re.sub(r"^[^\w.]+", "", raw_last)
         if last_word in abbreviations:
             continue
 

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2155,3 +2155,62 @@ def func(x) -> None:
     main(".")
     std = capsys.readouterr()
     assert E[305].ref not in std.out
+
+
+def test_fix_rst_directive_in_description_does_not_trigger_sig305(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """RST directives (.. note::) in descriptions do not fire SIG305.
+
+    The sentence tokenizer previously split on the space after the second
+    dot in '.. note::'.  A negative lookbehind in the tokenizer regex now
+    prevents splitting on '..' sequences.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def func(x) -> None:
+    """Summary.
+
+    :param x: A value. See also:
+
+        .. note::
+            Some important note.
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[305].ref not in std.out
+
+
+def test_fix_parenthesized_abbreviation_does_not_trigger_sig305(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Abbreviations inside parentheses do not fire SIG305.
+
+    'e.g.' preceded by '(' becomes '(e.g.' as the last token before the
+    split, which was not recognised as a known abbreviation.  The fix
+    strips leading punctuation before the abbreviation lookup.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def func(x) -> None:
+    """Summary.
+
+    :param x: Some mode (e.g. debug mode or release mode).
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[305].ref not in std.out


### PR DESCRIPTION
Closes #959

SIG305 fired incorrectly in two cases handled by the sentence tokenizer:

- Abbreviations inside parentheses, e.g. `(e.g. debug mode)` — the last token before the split was `(e.g.`, which was not recognised as a known abbreviation. Leading punctuation is now stripped before the abbreviation lookup.
- RST directives such as `.. note::` — the tokenizer split on the space after the second dot. A negative lookbehind now prevents splitting on `..` sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)