### PR TITLE
fix: false positive SIG305 for abbreviations before comma (#961)

### DIFF
--- a/changelog/961.fix.md
+++ b/changelog/961.fix.md
@@ -1,0 +1,1 @@
+false positive SIG305 for abbreviations before comma

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -256,7 +256,8 @@ class FunctionChecker:  # pylint: disable=too-few-public-methods
             if (
                 i
                 and (stripped := i.strip())[0].isalpha()
-                and stripped.lower().split()[0] not in _SENTENCE_ABBREVIATIONS
+                and stripped.lower().split()[0].rstrip(",;")
+                not in _SENTENCE_ABBREVIATIONS
             )
         ):
             # description is not capitalized

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2214,3 +2214,31 @@ def func(x) -> None:
     main(".")
     std = capsys.readouterr()
     assert E[305].ref not in std.out
+
+
+def test_fix_abbreviation_with_trailing_comma_does_not_trigger_sig305(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Abbreviations followed by a comma do not fire SIG305.
+
+    'e.g.,' and 'i.e.,' end with a trailing comma that was not stripped
+    before the SENTENCE_ABBREVIATIONS lookup, causing a false positive.
+    The fix strips trailing commas and semicolons before the lookup.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def func(x) -> None:
+    """Summary.
+
+    :param x: First value. e.g., debug or release.
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[305].ref not in std.out


### PR DESCRIPTION
Closes #961

SIG305 fired on parameter descriptions containing abbreviations followed by a comma (e.g., `e.g.,` / `i.e.,`) because the trailing comma was not stripped before the sentence-abbreviation lookup, so the word failed to match the abbreviation list and the text was treated as an uncapitalized new sentence.

The fix strips trailing commas and semicolons from the first word before the lookup, with a regression test in `tests/fix_test.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)