### PR TITLE
fix: false positive SIG306 for rst directives in descriptions (#963)

### DIFF
--- a/changelog/963.fix.md
+++ b/changelog/963.fix.md
@@ -1,0 +1,1 @@
+false positive SIG306 for rst directives in descriptions

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -48,6 +48,11 @@ def _last_prose_char(text: str) -> tuple[str | None, bool]:
                 in_block = False
             else:
                 continue
+        if stripped_ln.startswith(".."):
+            # a directive or comment, e.g. `.. versionchanged:: 2.0`,
+            # is not prose, and its indented content belongs to it
+            in_block = True
+            continue
         if stripped_ln.endswith("::"):
             in_block = True
         if stripped_ln:

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2242,3 +2242,33 @@ def func(x) -> None:
     main(".")
     std = capsys.readouterr()
     assert E[305].ref not in std.out
+
+
+def test_fix_rst_directive_ending_description_does_not_trigger_sig306(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """RST directives ending a param description do not fire SIG306.
+
+    A directive such as ``.. versionchanged:: 2.2`` is not prose, so a
+    description ending with one does not need a sentence terminator.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def func(x) -> None:
+    """Summary.
+
+    :param x: If set to `False`, disables legacy mode.
+
+        .. versionchanged:: 1.22.0
+        .. versionchanged:: 2.2
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[306].ref not in std.out


### PR DESCRIPTION
Closes #963

A parameter description ending with an RST directive such as `.. versionchanged:: 2.2` no longer fires SIG306. A directive (or comment) beginning with `..` is not prose, and its indented content belongs to it, so the sentence-terminator check now skips it when finding the last prose character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)