### PR TITLE
fix: false positive SIG306 for descriptions ending with a list (#969)

### DIFF
--- a/changelog/969.fix.md
+++ b/changelog/969.fix.md
@@ -1,0 +1,1 @@
+false positive SIG306 for descriptions ending with a list

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -6,6 +6,7 @@ Run docstring and signature checks for a single function.
 """
 
 import contextlib as _contextlib
+import re as _re
 import typing as _t
 
 import astroid as _ast
@@ -34,20 +35,29 @@ _VALID_ENDINGS = (
     "!",
     "?",
 )
+_LIST_ITEM = _re.compile(r"(?:[-*+]|#\.|\d+\.)(?:\s|$)")
 
 
 def _last_prose_char(text: str) -> tuple[str | None, bool]:
     # return the last character of non-code-block prose and whether the
-    # text ends inside a code block (a line ending with ::)
+    # text ends where a sentence terminator is not expected (inside a
+    # code block or directive, or on a list item)
     in_block = False
     last_char = None
+    para_start = None
     for line in text.strip().split("\n"):
         stripped_ln = line.strip()
         if in_block:
             if stripped_ln and line[:1] not in (" ", "\t"):
                 in_block = False
+                para_start = None
             else:
                 continue
+        if not stripped_ln:
+            para_start = None
+            continue
+        if para_start is None:
+            para_start = stripped_ln
         if stripped_ln.startswith(".."):
             # a directive or comment, e.g. `.. versionchanged:: 2.0`,
             # is not prose, and its indented content belongs to it
@@ -55,9 +65,11 @@ def _last_prose_char(text: str) -> tuple[str | None, bool]:
             continue
         if stripped_ln.endswith("::"):
             in_block = True
-        if stripped_ln:
-            last_char = stripped_ln[-1]
-    return last_char, in_block
+        last_char = stripped_ln[-1]
+    ends_on_list_item = para_start is not None and bool(
+        _LIST_ITEM.match(para_start),
+    )
+    return last_char, in_block or ends_on_list_item
 
 
 def check_function(func: _Function, config: _Config) -> _FunctionResult:
@@ -278,12 +290,12 @@ class FunctionChecker:  # pylint: disable=too-few-public-methods
             # description is not capitalized
             self._add(_E[305])
         # description-missing-period
-        # a description that ends inside an RST code block (introduced
-        # by a line ending with ::) does not need a sentence terminator
+        # a description that ends inside an RST code block or directive,
+        # or on a list item, does not need a sentence terminator
         if doc_description:
-            last_char, in_block = _last_prose_char(doc_description)
+            last_char, exempt = _last_prose_char(doc_description)
             if (
-                not in_block
+                not exempt
                 and last_char is not None
                 and last_char not in _VALID_ENDINGS
             ):

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2272,3 +2272,34 @@ def func(x) -> None:
     main(".")
     std = capsys.readouterr()
     assert E[306].ref not in std.out
+
+
+def test_fix_list_ending_description_does_not_trigger_sig306(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Descriptions ending with a list item do not fire SIG306.
+
+    List items conventionally are not sentence-terminated, so a
+    description whose last paragraph is a bullet or enumerated list
+    does not need to end in a period.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def func(x) -> None:
+    """Summary.
+
+    :param x: Individual types for which a formatter can be set are:
+
+        - 'bool'
+        - 'int'
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[306].ref not in std.out


### PR DESCRIPTION
Fixes #969

SIG306 fired when a parameter description ended with a bullet or enumerated list. List items are conventionally not sentence-terminated, so a description whose final paragraph is a list no longer requires a trailing period.

`_last_prose_char` now tracks the start of the current paragraph and reports the description as exempt when that paragraph begins with a list marker (`-`, `*`, `+`, `#.`, or an enumerated `1.`), alongside the existing code-block and directive exemptions.