### PR TITLE
fix: valid python in non-utf-8 encoding reported as broken file (#971)

### DIFF
--- a/changelog/971.fix.md
+++ b/changelog/971.fix.md
@@ -1,0 +1,1 @@
+valid python in non-utf-8 encoding reported as broken file

--- a/docsig/_parsers.py
+++ b/docsig/_parsers.py
@@ -7,6 +7,7 @@ import logging as _logging
 import os as _os
 from pathlib import Path as _Path
 from tokenize import TokenError as _TokenError
+from tokenize import detect_encoding as _detect_encoding
 
 import astroid as _ast
 
@@ -62,6 +63,18 @@ def parse_from_string(
     return parent
 
 
+def _source_encoding(file: _Path) -> str:
+    # follow the python tokenizer's own rules (pep 263 cookie or bom) so
+    # any file cpython can run can be read; fall back to utf-8 when
+    # detection itself fails, so undecodable files still surface as
+    # unicode-decode-error
+    try:
+        with file.open("rb") as fd:
+            return _detect_encoding(fd.readline)[0]
+    except SyntaxError:
+        return "utf-8"
+
+
 def parse_from_file(file: _Path, config: _Config) -> _Parent:
     """Build a Parent from a file containing Python code.
 
@@ -74,7 +87,7 @@ def parse_from_file(file: _Path, config: _Config) -> _Parent:
     :return: Parent for the parsed file or an error/empty Parent.
     """
     try:
-        code = file.read_text(encoding="utf-8")
+        code = file.read_text(encoding=_source_encoding(file))
         module_name = str(file)[:-3].replace(_os.sep, ".").replace("-", "_")
         parent = parse_from_string(code, config, module_name, file)
 

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2303,3 +2303,56 @@ def func(x) -> None:
     main(".")
     std = capsys.readouterr()
     assert E[306].ref not in std.out
+
+
+def test_fix_read_files_with_pep263_encoding_declaration(
+    tmp_path: Path,
+    main: FixtureMain,
+) -> None:
+    """Valid python declaring a non-utf-8 codec is checked, not failed.
+
+    Problem: Files were always read as utf-8, so valid python declaring
+    another codec with a pep 263 coding cookie could not be read at all
+    and surfaced as SIG902 with the critical exit status.
+
+    :param tmp_path: Create and return the temporary directory.
+    :param main: Mock ``main`` function.
+    """
+    file = tmp_path / "latin1.py"
+    template = '''\
+# -*- coding: latin-1 -*-
+# café
+def function(param: int) -> None:
+    """Summary.
+
+    :param param: A description.
+    """
+'''
+    file.write_bytes(template.encode("latin-1"))
+    assert main(file) == 0
+
+
+def test_fix_read_files_with_utf_8_bom(
+    tmp_path: Path,
+    main: FixtureMain,
+) -> None:
+    """Valid python with a utf-8 byte-order mark is checked, not failed.
+
+    Problem: Files were always read as plain utf-8, so the byte-order
+    mark some editors prepend leaked into the source and surfaced as
+    SIG901 invalid-syntax although cpython runs the file fine.
+
+    :param tmp_path: Create and return the temporary directory.
+    :param main: Mock ``main`` function.
+    """
+    file = tmp_path / "bom.py"
+    template = '''\
+def function(param: int) -> None:
+    """Summary.
+
+    :param param: A description.
+    """
+'''
+    # noinspection PyArgumentEqualDefault
+    file.write_bytes(b"\xef\xbb\xbf" + template.encode("utf-8"))
+    assert main(file) == 0


### PR DESCRIPTION
Fixes #971

Source files were always read as UTF-8, so valid Python that CPython runs fine was reported as unparseable — a PEP 263 coding cookie surfaced as SIG902 with the critical exit status, and a UTF-8 BOM leaked into the source and surfaced as SIG901 invalid-syntax.

`parse_from_file` now decodes using `tokenize.detect_encoding`, following the tokenizer's own rules for both the coding cookie and the BOM. Detection falling back to UTF-8 on `SyntaxError` keeps genuinely undecodable files surfacing as a unicode decode error rather than being silently swallowed.