### PR TITLE
fix: default excludes for paths below the invocation dir (#973)

### DIFF
--- a/changelog/973.fix.md
+++ b/changelog/973.fix.md
@@ -1,0 +1,1 @@
+default excludes for paths below the invocation dir

--- a/docsig/_config.py
+++ b/docsig/_config.py
@@ -20,8 +20,11 @@ from .messages import Messages as _Messages
 
 PYPROJECT_TOML = "pyproject.toml"
 
+# the leading optional group allows the excluded dir to sit at any
+# depth, so the default excludes apply however the checked path is
+# given, e.g. a subdir or an absolute path, not only relative to cwd
 DEFAULT_EXCLUDES = """\
-(?x)^(
+(?x)^(?:.*[\\\\/])?(
     |\\.?venv[\\\\/].*
     |\\.git[\\\\/].*
     |\\.hg[\\\\/].*
@@ -33,7 +36,7 @@ DEFAULT_EXCLUDES = """\
     |\\.tox[\\\\/].*
     |\\.vscode[\\\\/].*
     |_?build[\\\\/].*
-    |.*[\\\\/]__pycache__[\\\\/].*
+    |__pycache__[\\\\/].*
     |dist[\\\\/].*
     |node_modules[\\\\/].*
 )$

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -19,6 +19,7 @@ from docsig.messages import E
 
 from . import (
     TREE,
+    WILL_ERROR,
     FixtureFlake8,
     FixtureInitFile,
     FixtureInitPyprojectTomlFile,
@@ -2356,3 +2357,30 @@ def function(param: int) -> None:
     # noinspection PyArgumentEqualDefault
     file.write_bytes(b"\xef\xbb\xbf" + template.encode("utf-8"))
     assert main(file) == 0
+
+
+def test_fix_default_excludes_apply_below_invocation_path(
+    make_tree: FixtureMakeTree,
+    main: FixtureMain,
+) -> None:
+    """Default excludes apply however the checked path is given.
+
+    Problem: The default exclude patterns were anchored to the start of
+    the path as given, so they only matched when the excluded dir sat
+    directly under the current working directory; checking a
+    subdirectory or an absolute path descended into venvs and other
+    excluded dirs.
+
+    :param make_tree: Create the directory tree from dict mapping.
+    :param main: Mock ``main`` function.
+    """
+    make_tree(
+        {
+            "proj": {
+                ".venv": {"file.py": [WILL_ERROR]},
+                "__pycache__": {"file.py": [WILL_ERROR]},
+            },
+        },
+    )
+    assert main("proj", test_flake8=False) == 0
+    assert main(Path.cwd() / "proj", test_flake8=False) == 0


### PR DESCRIPTION
Fixes #973

The default exclude patterns were anchored to the start of the path as given, so they only matched when the excluded directory sat directly under the current working directory. Checking a subdirectory or an absolute path descended into venvs and other excluded directories.

`DEFAULT_EXCLUDES` now carries an optional leading `(?:.*[\\/])?` group, so an excluded directory is matched at any depth. The special-cased `.*[\\/]__pycache__[\\/].*` alternative is dropped, since the new prefix covers it generically.

Note this widens the defaults: `dist/`, `_?build/`, `node_modules/`, `.venv/` and friends are now excluded at any depth, where previously only `__pycache__` was. That is the intent — it matches how the checked path is given rather than where it happens to be rooted — but it does mean a source package legitimately named e.g. `build` nested inside a project would now be skipped.