### PR TITLE
fix: commandline exclude ignored when configured in pyproject (#978)

### DIFF
--- a/changelog/978.fix.md
+++ b/changelog/978.fix.md
@@ -1,0 +1,1 @@
+commandline exclude ignored when configured in pyproject

--- a/docsig/_config.py
+++ b/docsig/_config.py
@@ -75,8 +75,8 @@ def merge_configs(
 ) -> dict[str, _t.Any]:
     """Merge the second config dict into the first and return the first.
 
-    List values in obj2 are added to lists in obj1; other keys are
-    overridden.
+    Values in obj2 are added to lists in obj1, so list options union
+    across config layers; other keys are overridden.
 
     :param obj1: Base config dict (modified in place).
     :param obj2: Overrides and extra keys to merge in.
@@ -84,8 +84,10 @@ def merge_configs(
     """
     for key, n_val in obj1.items():
         c_val = obj2.get(key)
-        if isinstance(c_val, list) and isinstance(n_val, list):
-            obj1[key].extend(c_val)
+        if isinstance(n_val, list) and c_val:
+            obj1[key].extend(
+                c_val if isinstance(c_val, list) else [c_val],
+            )
         elif c_val:
             obj1[key] = c_val
 
@@ -243,6 +245,8 @@ def build_parser() -> _ArgumentParser:
     parser.add_argument(
         "-e",
         "--exclude",
+        action="append",
+        default=[],
         metavar="PATTERN",
         help="regular expression of files or dirs to exclude from checks",
     )

--- a/docsig/_core.py
+++ b/docsig/_core.py
@@ -101,7 +101,7 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
     verbose: bool = False,
     target: _Messages | None = None,
     disable: _Messages | None = None,
-    exclude: str | None = None,
+    exclude: str | list[str] | None = None,
     excludes: list[str] | None = None,
 ) -> int:
     """Run docstring/signature checks on paths or a string and report.
@@ -135,8 +135,8 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
     :param verbose: Increase output verbosity.
     :param target: List of errors to target.
     :param disable: List of errors to disable.
-    :param exclude: Regular expression of files and dirs to exclude from
-        checks.
+    :param exclude: Regular expression(s) of files and dirs to exclude
+        from checks, joined with the default exclusions.
     :param excludes: Files or dirs to exclude from checks.
     :return: Exit code (non-zero if any check failed).
     """
@@ -155,8 +155,10 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
         stacklevel=5,
     )
     exclude_patterns = [_DEFAULT_EXCLUDES]
-    if exclude is not None:
+    if isinstance(exclude, str):
         exclude_patterns.append(exclude)
+    elif exclude:
+        exclude_patterns.extend(exclude)
 
     # while some params could be taken out for one time use (such as
     # verbose), bundling all the configuration together makes it easier

--- a/docsig/plugin/_validate_pyproject.py
+++ b/docsig/plugin/_validate_pyproject.py
@@ -66,11 +66,13 @@ class ValidatePyproject(dict[str, _t.Any]):
             self["properties"][name] = {"default": action.default}
             if isinstance(action.default, bool):
                 self["properties"][name]["type"] = "boolean"
+            elif type(action).__name__ == "_AppendAction":
+                # append options take a single value or a list
+                self["properties"][name]["type"] = ["string", "array"]
+                self["properties"][name]["items"] = {"type": "string"}
             elif isinstance(action.default, list) or action.nargs in _NARGS:
                 self["properties"][name]["type"] = "array"
                 self["properties"][name]["items"] = {"type": "string"}
-            elif action.type is None:
-                self["properties"][name]["type"] = "string"
 
             if action.help:
                 description = action.help

--- a/tests/_test.py
+++ b/tests/_test.py
@@ -1240,12 +1240,13 @@ def test_validate_pyproject(monkeypatch: pytest.MonkeyPatch) -> None:
                 "default": [],
             },
             "exclude": {
-                "type": "string",
+                "type": ["string", "array"],
+                "items": {"type": "string"},
                 "description": (
                     "regular expression of files or dirs to exclude from"
                     " checks"
                 ),
-                "default": None,
+                "default": [],
             },
             "excludes": {
                 "type": "array",
@@ -1443,6 +1444,8 @@ def test_validate_pyproject(monkeypatch: pytest.MonkeyPatch) -> None:
     parser.add_argument(
         "-e",
         "--exclude",
+        action="append",
+        default=[],
         metavar="PATTERN",
         help="regular expression of files or dirs to exclude from checks",
     )

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2415,3 +2415,46 @@ def function(a: int, b: int, c: int) -> None:
     main(".")
     std = capsys.readouterr()
     assert E[305].ref not in std.out
+
+
+def test_fix_exclude_ignored_when_configured_in_pyproject(
+    init_pyproject_toml: FixtureInitPyprojectTomlFile,
+    make_tree: FixtureMakeTree,
+    main: FixtureMain,
+) -> None:
+    """Test commandline exclude merges with pyproject exclude.
+
+    Problem: An exclude pattern configured in pyproject.toml silently
+    replaced a pattern passed on the commandline, so the commandline
+    pattern was ignored.
+
+    :param init_pyproject_toml: Initialize a test pyproject.toml file.
+    :param make_tree: Create the directory tree from dict mapping.
+    :param main: Mock ``main`` function.
+    """
+    make_tree({"a": {"file.py": [WILL_ERROR]}, "b": {"file.py": [WILL_ERROR]}})
+    init_pyproject_toml({"exclude": r"a[\\/].*"})
+    assert main(".", "--exclude", r"b[\\/].*", test_flake8=False) == 0
+
+
+def test_fix_exclude_repeated_argument(
+    make_tree: FixtureMakeTree,
+    main: FixtureMain,
+) -> None:
+    """Test exclude patterns accumulate when the argument is repeated.
+
+    :param make_tree: Create the directory tree from dict mapping.
+    :param main: Mock ``main`` function.
+    """
+    make_tree({"a": {"file.py": [WILL_ERROR]}, "b": {"file.py": [WILL_ERROR]}})
+    assert (
+        main(
+            ".",
+            "--exclude",
+            r"a[\\/].*",
+            "--exclude",
+            r"b[\\/].*",
+            test_flake8=False,
+        )
+        == 0
+    )


### PR DESCRIPTION
Closes #978

`merge_configs` only unioned two values when both were lists, and `--exclude`
was a plain single-value option, so a commandline pattern replaced the
`pyproject.toml` one instead of merging with it.

- `--exclude` becomes an `append` action defaulting to `[]`, so it can be
  repeated and accumulates.
- `merge_configs` unions into a list whenever the base value is a list,
  coercing a scalar override so a string in `pyproject.toml` merges with
  commandline values.
- `docsig(exclude=...)` accepts `str | list[str]` for the same reason.
- The pyproject schema emits `["string", "array"]` for append options, so both
  forms validate.

Adds regression tests for the pyproject/commandline merge and for a repeated
`--exclude` argument.