### PR TITLE
fix: syntax error reported for description on line after field (#980)

### DIFF
--- a/changelog/980.fix.md
+++ b/changelog/980.fix.md
@@ -1,0 +1,1 @@
+syntax error reported for description on line after field

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -264,8 +264,8 @@ class FunctionChecker:  # pylint: disable=too-few-public-methods
         doc_description = doc.description
         if doc_description is None and doc.name is not None:
             self._add(_E[301])
-        elif doc_description is not None and not doc_description.startswith(
-            " ",
+        elif doc_description is not None and self._description_syntax_error(
+            doc_description,
         ):
             # syntax-error-in-description
             self._add(_E[302])
@@ -300,6 +300,42 @@ class FunctionChecker:  # pylint: disable=too-few-public-methods
                 and last_char not in _VALID_ENDINGS
             ):
                 self._add(_E[306])
+
+    @staticmethod
+    def _description_syntax_error(description: str) -> bool:
+        # a field body may start on the line after the field name, so a
+        # newline followed by an indented body is well formed; within
+        # that body a deeper indent directly after a body line is not
+        # valid rst ("unexpected indentation") unless the line above
+        # opens a literal block or is a list item
+        if description.startswith(" "):
+            return False
+
+        if not description.startswith("\n"):
+            return True
+
+        prev_indent: int | None = None
+        prev_text = ""
+        seen = False
+        for line in description.splitlines()[1:]:
+            stripped_ln = line.strip()
+            if not stripped_ln:
+                prev_indent = None
+                continue
+
+            seen = True
+            indent = len(line) - len(line.lstrip())
+            if (
+                prev_indent is not None
+                and indent > prev_indent
+                and not prev_text.endswith("::")
+                and not _LIST_ITEM.match(prev_text)
+            ):
+                return True
+
+            prev_indent, prev_text = indent, stripped_ln
+
+        return not seen
 
     def _sig4xx_parameters(self, doc: _Param, sig: _Param) -> None:
         # freeze result as it is a property and PyCharm complains

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2458,3 +2458,32 @@ def test_fix_exclude_repeated_argument(
         )
         == 0
     )
+
+
+def test_fix_description_on_line_after_field_not_syntax_error(
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Field bodies starting on the following line are well formed.
+
+    Problem: The multi-line rst field form, with the description on an
+    indented line below ``:param name:``, was reported as SIG302
+    syntax-error-in-description although it is one of the two canonical
+    sphinx field layouts.
+
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(param) -> None:
+    """Summary.
+
+    :param param:
+        A description of the parameter,
+        continued on another line.
+
+            An indented block after a paragraph break.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0


### PR DESCRIPTION
Closes #980

SIG302 was raised whenever a field description did not begin with a space,
which rejects the valid rst layout where the field body starts on the line
below the field name.

Replaces that test with `_description_syntax_error`, which accepts a leading
newline followed by an indented body and only flags a genuine "unexpected
indentation" — a deeper indent directly after a body line, unless that line
opens a literal block (`::`) or is a list item. An empty body is still an
error.

Adds a regression test covering the multi-line field form, including a
deeper-indented block after a paragraph break.