### PR TITLE
fix: gitignore resolved from cwd instead of checked path (#986)

### DIFF
--- a/changelog/986.fix.md
+++ b/changelog/986.fix.md
@@ -1,0 +1,1 @@
+gitignore resolved from cwd instead of checked path

--- a/docsig/_core.py
+++ b/docsig/_core.py
@@ -24,7 +24,6 @@ from ._parsers import parse_from_file as _parse_from_file
 from ._parsers import parse_from_string as _parse_from_string
 from ._report import report as _report
 from ._traverse import run_checks as _run_checks
-from ._utils import get_parent_that_has as _get_parent_that_has
 from ._utils import print_checks as _print_checks
 from .messages import E as _E
 from .messages import Messages as _Messages
@@ -206,8 +205,7 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
         return _report(failures, config)
 
     retcodes = _RetCode()
-    repo = _get_parent_that_has(".git/HEAD")
-    files = _Files(path, config.filters, repo)
+    files = _Files(path, config.filters)
     for file in files:
         failures = runner(file, config)
         retcode = _report(failures, config, str(file))

--- a/docsig/_files.py
+++ b/docsig/_files.py
@@ -58,26 +58,48 @@ def _glob(path: _Path, pattern: str) -> bool:
     return _WcPath(str(path)).globmatch(pattern)  # type: ignore
 
 
+def _find_repo(path: _Path) -> _Path | None:
+    # the root of the repo the path belongs to, identified by a .git
+    # entry; .git is a dir holding a HEAD file in a normal checkout and
+    # a file pointing to the real git dir in worktrees and submodules
+    resolved = path.resolve()
+    for parent in (resolved, *resolved.parents):
+        git = parent / ".git"
+        if (git / "HEAD").is_file() or git.is_file():
+            return parent
+
+    return None
+
+
 class Files(list[_Path]):
     """Collect paths to check (gitignore and exclude applied).
 
     :param paths: Path(s) to collect (files or directories).
     :param filters: Filters object.
-    :param repo: Path to the repo root.
     """
 
     def __init__(
         self,
         paths: tuple[str | _Path, ...],
         filters: _Filters,
-        repo: _Path | None = None,
     ) -> None:
         super().__init__()
         self._include_ignored = filters.include_ignored
-        self._gitignore = _Gitignore(repo)
+        self._repo: _Path | None = None
+        self._gitignore = _Gitignore(None)
         logger = _logging.getLogger(__package__)
+        # gitignore patterns come from the repo each checked path
+        # belongs to, which is not necessarily the repo containing the
+        # current working directory
+        gitignores: dict[_Path | None, _Gitignore] = {}
         for path in paths:
-            self._populate(_Path(path))
+            root = _Path(path)
+            self._repo = _find_repo(root)
+            if self._repo not in gitignores:
+                gitignores[self._repo] = _Gitignore(self._repo)
+
+            self._gitignore = gitignores[self._repo]
+            self._populate(root)
 
         for path in list(self):
             if any(_re.match(i, str(path)) for i in filters.exclude) or any(
@@ -97,7 +119,7 @@ class Files(list[_Path]):
 
             raise FileNotFoundError(root)
 
-        if not self._include_ignored and self._gitignore.match_file(root):
+        if not self._include_ignored and self._ignored(root):
             logger.debug(FILE_INFO, root, "in gitignore, skipping")
             return
 
@@ -107,3 +129,17 @@ class Files(list[_Path]):
         if root.is_dir():
             for path in root.iterdir():
                 self._populate(path)
+
+    def _ignored(self, path: _Path) -> bool:
+        # gitignore patterns are relative to the repo root, so the path
+        # is matched relative to the repo root too, wherever the run
+        # was invoked from
+        if self._repo is None:
+            return False
+
+        try:
+            relative = path.resolve().relative_to(self._repo)
+        except ValueError:
+            return False
+
+        return self._gitignore.match_file(relative)

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2487,3 +2487,60 @@ def function(param) -> None:
 '''
     init_file(template)
     assert main(".") == 0
+
+
+def test_fix_gitignore_applied_in_worktree(
+    make_tree: FixtureMakeTree,
+    main: FixtureMain,
+) -> None:
+    """Gitignore filtering works where ``.git`` is a file.
+
+    Problem: The repo was identified by the presence of a .git/HEAD
+    file, but in worktrees and submodules .git is a file pointing to
+    the real git dir, so gitignore filtering was silently disabled
+    there.
+
+    :param make_tree: Create the directory tree from dict mapping.
+    :param main: Mock ``main`` function.
+    """
+    make_tree(
+        {
+            ".git": ["gitdir: /some/repo/.git/worktrees/branch"],
+            ".gitignore": ["skip.py"],
+            "skip.py": [WILL_ERROR],
+        },
+    )
+    assert main(".", test_flake8=False) == 0
+
+
+def test_fix_gitignore_resolved_from_checked_path(
+    make_tree: FixtureMakeTree,
+    main: FixtureMain,
+) -> None:
+    """Gitignore patterns come from the checked path's own repo.
+
+    Problem: The repo was resolved by walking up from the current
+    working directory, not from the path being checked, so a tree
+    outside the cwd's repo was filtered with the wrong repo's
+    gitignore patterns, or none at all.
+
+    :param make_tree: Create the directory tree from dict mapping.
+    :param main: Mock ``main`` function.
+    """
+    make_tree(
+        {
+            "repo": {
+                ".git": {"HEAD": ["ref: refs/heads/master"]},
+                ".gitignore": ["skip.py"],
+                "skip.py": [WILL_ERROR],
+            },
+            "outside.py": [WILL_ERROR],
+        },
+    )
+    # cwd is not a repo, but the checked path is
+    assert main("repo", test_flake8=False) == 0
+
+    # a symlink resolving outside the repo cannot be matched against
+    # the repo's patterns and so is still checked
+    (Path("repo") / "linked.py").symlink_to(Path.cwd() / "outside.py")
+    assert main("repo", test_flake8=False) != 0


### PR DESCRIPTION
Closes #986

Resolve the repo for gitignore filtering by walking up from each checked
path rather than from the current working directory, and match paths
relative to that repo root so patterns apply wherever the run was invoked
from. Also recognise a `.git` file, so worktrees and submodules are treated
as repos.