### PR TITLE
fix: stop false positives for typed parameter fields (#988)

### DIFF
--- a/changelog/988.fix.md
+++ b/changelog/988.fix.md
@@ -1,0 +1,1 @@
+stop false positives for typed parameter fields

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -29,6 +29,15 @@ VALID_DESCRIPTION = " A valid description."
 # same as ``-> None`` for documentation purposes
 _NO_RETURN = ("NoReturn", "Never")
 
+#: a word in a param field after the leading keyword: a (possibly
+#: starred) name or type expression, in which ``. , | [ ]`` join word
+#: characters so types such as ``list[str]``, ``t.Any``, ``int|str``,
+#: and the split words of ``dict[str, int]`` hold together; a trailing
+#: ``,`` or bracket belongs to a bracketed type, while a trailing ``.``
+#: or ``|`` stays outside the word so it is still read as a bad
+#: closing token
+_FIELD_WORD = r"(?:\\?\*){0,2}\w+(?:[.,|\[\]]+\w+)*[,\[\]]*"
+
 
 class RetType(_Enum):
     """Possible kinds of return annotation."""
@@ -371,8 +380,8 @@ class Docstring(_Stub):
         # noinspection RegExpSingleCharAlternation
         for match in _re.findall(
             r"^[ \t]*:((?:\\?\*){0,2}[\w]+"
-            r"(?:\s+(?:\\?\*){0,2}[\w]+|"
-            r"\s\|\s(?:\\?\*){0,2}[\w]+)*)"
+            rf"(?:\s+{_FIELD_WORD}|"
+            rf"\s\|\s{_FIELD_WORD})*)"
             r"([^\w\s\\*])"
             r"((?:.|\n)*?)(?=\n[ \t]*:|\Z)",
             string,

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2544,3 +2544,31 @@ def test_fix_gitignore_resolved_from_checked_path(
     # the repo's patterns and so is still checked
     (Path("repo") / "linked.py").symlink_to(Path.cwd() / "outside.py")
     assert main("repo", test_flake8=False) != 0
+
+
+def test_fix_typed_param_fields_with_brackets_pipes_or_dots(
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Types with brackets, pipes, or dots parse in a param field.
+
+    Problem: The param-field regex only recognized plain words, so
+    valid sphinx typed fields such as ``:param list[str] x:`` had the
+    bracket read as the token closing the name, producing spurious
+    SIG302, SIG305, and SIG404 for correctly documented params.
+
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(a: list, b: dict, c: int, d: object) -> None:
+    """Summary.
+
+    :param list[str] a: A description.
+    :param dict[str, int] b: A description.
+    :param int|str c: A description.
+    :param t.Any d: A description.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0


### PR DESCRIPTION
Closes #988

The param-field regex only accepted plain words for the inline type and
name, so the first non-word character — `[`, `]`, `|`, or `.` — was read
as the token closing the field name, and the rest of the field was taken as
the description. Correctly documented parameters such as `:param list[str] a:`
were reported as SIG302, SIG305, and SIG404.

Field words now hold together across `. , | [ ]`, so `list[str]`, `t.Any`,
`int|str`, and the split words of `dict[str, int]` parse as one word. A
trailing `.` or `|` deliberately stays outside the word, so a genuinely bad
closing token is still reported.