### PR TITLE
fix: google docstrings undetected by keyword args section (#990)

### DIFF
--- a/changelog/990.fix.md
+++ b/changelog/990.fix.md
@@ -1,0 +1,1 @@
+google docstrings undetected by keyword args section

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -326,8 +326,8 @@ class Docstring(_Stub):
             return "numpy"
 
         if _re.search(
-            r"^(Args|Arguments|Parameters|Returns|Yields|Raises|"
-            r"Attributes|Example|Examples):\s*$",
+            r"^(Args|Arguments|Keyword Args|Keyword Arguments|Parameters|"
+            r"Returns|Yields|Raises|Attributes|Example|Examples):\s*$",
             string,
             _re.MULTILINE,
         ):

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2572,3 +2572,29 @@ def function(a: list, b: dict, c: int, d: object) -> None:
 '''
     init_file(template)
     assert main(".") == 0
+
+
+def test_fix_google_keyword_args_section_recognized(
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """A google docstring is detected by its Keyword Args section.
+
+    Problem: ``Keyword Args`` and ``Keyword Arguments`` were missing
+    from the google section headers used to detect google style, so a
+    docstring documenting only keyword arguments was never converted
+    and its params were invisible, reported as SIG203 params-missing.
+
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(**kwargs: str) -> None:
+    """Summary.
+
+    Keyword Args:
+        alpha (str): A description.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0


### PR DESCRIPTION
Adds `Keyword Args` and `Keyword Arguments` to the google section headers
used to detect google style, so a docstring documenting only keyword
arguments is converted instead of being left unparsed with no documented
params.

Fixes #990