### PR TITLE
fix: indent anomaly reported for tab indented docstrings (#996)

### DIFF
--- a/changelog/996.fix.md
+++ b/changelog/996.fix.md
@@ -1,0 +1,1 @@
+indent anomaly reported for tab indented docstrings

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -357,12 +357,25 @@ class Docstring(_Stub):
     @staticmethod
     def _indent_anomaly(string: str) -> bool:
         # report whether the first indented param field is indented
-        # with an odd number of spaces
+        # with an odd number of spaces relative to the docstring's own
+        # margin, so a uniformly indented docstring, e.g. one indented
+        # with tabs, is not an anomaly
+        # tabs are expanded as cleandoc expands them for parsing
         # description or anything else is out of scope
-        string = _DIRECTIVE.sub("", string)
-        for line in string.splitlines():
+        string = _DIRECTIVE.sub("", string.expandtabs())
+        lines = string.splitlines()
+        # the margin is the least indent below the summary line; the
+        # last line is counted even when blank as it carries the
+        # indent of the closing quotes
+        indents = [
+            len(line) - len(line.lstrip())
+            for line in lines[1:]
+            if line.strip() or line is lines[-1]
+        ]
+        margin = min(indents, default=0)
+        for line in lines:
             if line.lstrip().startswith(":"):
-                indent = len(line) - len(line.lstrip())
+                indent = len(line) - len(line.lstrip()) - margin
                 if indent > 0:
                     return indent % 2 != 0
 

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2598,3 +2598,27 @@ def function(**kwargs: str) -> None:
 '''
     init_file(template)
     assert main(".") == 0
+
+
+def test_fix_no_indent_anomaly_for_tab_indented_source(
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Tab-indented files do not report an indent anomaly.
+
+    Problem: The indent probe ran on the raw docstring before cleandoc
+    expanded tabs, counting a tab as one character, so every param in
+    a tab-indented file was reported as SIG401 incorrect-indent.
+
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = (
+        "def function(param: int) -> None:\n"
+        '\t"""Summary.\n'
+        "\n"
+        "\t:param param: A description.\n"
+        '\t"""\n'
+    )
+    init_file(template)
+    assert main(".") == 0


### PR DESCRIPTION
The SIG401 indent probe measured a field's indent from column zero on the raw
docstring, before `cleandoc` expanded tabs. A tab counted as one character, so
every field in a tab-indented docstring landed on an odd indent and was
reported as incorrectly indented.

The probe now expands tabs the same way `cleandoc` does for parsing, and
measures each field relative to the docstring's own margin — the least indent
below the summary line — so a uniformly indented docstring is not an anomaly
and only fields out of step with their neighbours are flagged.

Closes #996
