### PR TITLE
fix: return doc required for quoted none annotation (#998)

### DIFF
--- a/changelog/998.fix.md
+++ b/changelog/998.fix.md
@@ -1,0 +1,1 @@
+return doc required for quoted none annotation

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -96,6 +96,15 @@ class RetType(_Enum):
     @staticmethod
     def _annotates_none(returns: _ast.nodes.NodeNG | None) -> bool:
         if isinstance(returns, _ast.nodes.Const):
+            if isinstance(returns.value, str):
+                # a quoted annotation, e.g. -> "None", is legal
+                # forward-reference style and annotates whatever the
+                # string names
+                return returns.value.split(".")[-1] in (
+                    "None",
+                    *_NO_RETURN,
+                )
+
             return returns.value is None
 
         if isinstance(returns, _ast.nodes.Name):

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2622,3 +2622,39 @@ def test_fix_no_indent_anomaly_for_tab_indented_source(
     )
     init_file(template)
     assert main(".") == 0
+
+
+def test_fix_quoted_none_annotation_not_a_value_return(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """A quoted ``-> "None"`` annotation needs no return doc.
+
+    Problem: A quoted annotation is a string constant, and only the
+    ``None`` constant itself was recognized as annotating no return,
+    so the legal forward-reference style ``-> "None"`` was classified
+    as a value return and reported SIG503 return-missing.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function_none() -> "None":
+    """Summary."""
+
+
+def function_no_return() -> "typing.NoReturn":
+    """Summary."""
+
+
+def function_int() -> "int":
+    """Summary."""
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert "function_none" not in std.out
+    assert "function_no_return" not in std.out
+    assert "function_int" in std.out


### PR DESCRIPTION
Closes #998

`RetType._annotates_none` only recognised the bare `None` constant, so a quoted
annotation — which reaches the AST as a string `Const` — fell through to
`RetType.SOME` and docsig demanded a return description for `-> "None"`.

String constants are now unwrapped and matched against `None`/`NoReturn`/`Never`
(taking the last dotted segment, so `"typing.NoReturn"` works too). Quoted
annotations naming a real type, e.g. `-> "int"`, still report as before.