### PR TITLE
fix: json line zero for whole file syntax errors (#1000)

### DIFF
--- a/changelog/1000.fix.md
+++ b/changelog/1000.fix.md
@@ -1,0 +1,1 @@
+json line zero for whole file syntax errors

--- a/docsig/_report.py
+++ b/docsig/_report.py
@@ -134,7 +134,7 @@ def report(
 
             obj.append(
                 {
-                    "line": None if entry.retcode == 2 else item.line,
+                    "line": None if entry.retcode >= 2 else item.line,
                     "message": item.message,
                     "exit": item.exit,
                 },

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -5,6 +5,7 @@ tests.fix_test
 
 # pylint: disable=protected-access,line-too-long,too-many-lines
 import io
+import json
 import pickle
 from pathlib import Path
 
@@ -2658,3 +2659,31 @@ def function_int() -> "int":
     assert "function_none" not in std.out
     assert "function_no_return" not in std.out
     assert "function_int" in std.out
+
+
+def test_fix_json_null_line_for_syntax_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    main: FixtureMain,
+) -> None:
+    """JSON reports a null line number for syntax errors.
+
+    Problem: The null line marking a whole-file error was keyed on
+    exit status 2 only, but a syntax error carries exit status 123, so
+    SIG901 serialized with line 0 while the other whole-file errors
+    correctly serialized with null.
+
+    :param monkeypatch: Mock patch environment and attributes.
+    :param tmp_path: Create and return the temporary directory.
+    :param capsys: Capture sys out.
+    :param main: Mock ``main`` function.
+    """
+    file = tmp_path / "syntax_error.py"
+    file.write_text("def function(:\n", encoding="utf-8")
+    monkeypatch.setenv("_DOCSIG_FORMAT_JSON", "1")
+    assert main(file, test_flake8=False) == 123
+    std = capsys.readouterr()
+    issues = json.loads(std.out)
+    assert issues[0]["line"] is None
+    assert issues[0]["exit"] == 123


### PR DESCRIPTION
Closes #1000

The JSON reporter nulls the line number for errors that apply to a whole file rather than a specific line, but the condition was keyed on exit status `2` exactly. A syntax error (`SIG901`) carries exit status `123`, so it fell through to `item.line` and serialized as `"line": 0`.

Widening the check to `entry.retcode >= 2` covers every whole-file exit status, so `SIG901` now serializes with `"line": null` like the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)