### PR TITLE
fix: documentation undetected under unknown section headers (#1002)

### DIFF
--- a/changelog/1002.fix.md
+++ b/changelog/1002.fix.md
@@ -1,0 +1,1 @@
+documentation undetected under unknown section headers

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -49,19 +49,30 @@ _DIRECTIVE = _re.compile(r"^[ \t]*\.\..*\n(?:[ \t]+.*\n)*", _re.MULTILINE)
 #: an rst field such as ``:param:``, marking a docstring as already rst
 _RST_FIELD = _re.compile(r"^:\w+", _re.MULTILINE)
 
+#: every section name napoleon knows, longest first so multi-word names
+#: are preferred; derived from napoleon itself rather than hand-listed,
+#: because a hand-listed subset silently stops docstrings it does not
+#: recognise from ever reaching napoleon, hiding their params
+_SECTION_NAMES = "|".join(
+    _re.escape(name)
+    for name in sorted(
+        # pylint: disable-next=protected-access
+        _s.GoogleDocstring("")._sections,  # type: ignore
+        key=len,
+        reverse=True,
+    )
+)
+
 #: a numpy section header such as ``Returns`` underlined with dashes
 _NUMPY_SECTION = _re.compile(
-    r"^(Parameters|Other Parameters|Returns|Yields|Raises|"
-    r"See Also|Notes|Examples|Attributes|Methods)\n"
-    r"\s*-{3,}\s*$",
-    _re.MULTILINE,
+    rf"^({_SECTION_NAMES})\n\s*-{{3,}}\s*$",
+    _re.MULTILINE | _re.IGNORECASE,
 )
 
 #: a Google section header such as ``Args:``
 _GOOGLE_SECTION = _re.compile(
-    r"^(Args|Arguments|Keyword Args|Keyword Arguments|Parameters|"
-    r"Returns|Yields|Raises|Attributes|Example|Examples):\s*$",
-    _re.MULTILINE,
+    rf"^({_SECTION_NAMES}):\s*$",
+    _re.MULTILINE | _re.IGNORECASE,
 )
 
 #: a return field such as ``:return:``, capturing its description

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2687,3 +2687,92 @@ def test_fix_json_null_line_for_syntax_error(
     issues = json.loads(std.out)
     assert issues[0]["line"] is None
     assert issues[0]["exit"] == 123
+
+
+def test_fix_napoleon_sections_missed_by_the_section_gate(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """Every section napoleon converts reaches napoleon.
+
+    Problem: The google and numpy section headers were hand-listed
+    subsets of the sections napoleon knows, and the two lists had
+    drifted apart from each other as well as from napoleon, so a
+    docstring headed by a section missing from its list was never
+    converted and all of its documented params were invisible. The
+    lists were case sensitive too, while napoleon lowercases a header
+    before matching it.
+
+    Documentation hidden this way also hid the violations it should
+    raise, so a property documenting a return goes unreported until its
+    section reaches napoleon.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function_1(alpha: str) -> None:
+    """Summary.
+
+    Keyword Arguments
+    -----------------
+    alpha : str
+        The alpha value.
+    """
+
+
+def function_2(alpha: str) -> None:
+    """Summary.
+
+    Other Parameters:
+        alpha (str): The alpha value.
+    """
+
+
+def function_3(alpha: str) -> None:
+    """Summary.
+
+    Args
+    ----
+    alpha : str
+        The alpha value.
+    """
+
+
+def function_4() -> int:
+    """Summary.
+
+    Return:
+        The result.
+    """
+    return 1
+
+
+def function_5(alpha: str) -> None:
+    """Summary.
+
+    parameters:
+        alpha (str): The alpha value.
+    """
+
+
+class Klass:
+    """Summary."""
+
+    @property
+    def prop(self) -> int:
+        """Summary.
+
+        Return:
+            The result.
+        """
+        return 1
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[203].ref not in std.out
+    assert E[503].ref not in std.out
+    assert E[505].ref in std.out


### PR DESCRIPTION
Closes #1002

Source the docstring section names from napoleon itself instead of two
hand-listed subsets that had drifted apart from each other as well as from
napoleon, and match them case insensitively as napoleon does.

A docstring headed by a section missing from its list never reached napoleon, so
none of its documentation was converted to rst and docsig reported it as
missing.

## Verification

- The section sets are shared: `GoogleDocstring._sections` and
  `NumpyDocstring._sections` are the same 34 names, so one pattern serves both
  gates.
- `IGNORECASE` is faithful: both `_is_section_header` implementations call
  `.lower()` before matching `_sections`.
- The fix test fails on master and passes with the fix.

## Upgrade impact — for the release notes

On a 28,224-docstring sample, 78 docstrings begin reaching napoleon that
previously did not, dominated by `Return` (59), then `Notes`, `References`,
`See Also`, `Note`, `TODO`, a lowercase `parameters`, and `Example`. Measured
verdict change across the affected files:

| code | before | after |
| --- | --- | --- |
| SIG503 | 155 | 148 |
| SIG501 | 153 | 153 |
| SIG505 | 0 | 46 |

The SIG503/SIG501 drops are the fix itself — return documentation is now seen.
The new SIG505s are documentation that was always wrong but invisible: a
property documenting `Return:` correctly reports `return statement documented
for property`. Worth calling out when this release ships, since it can surface
new violations on unchanged code.