### PR TITLE
fix: numpy sections undetected with trailing whitespace (#1007)

### DIFF
--- a/changelog/1007.fix.md
+++ b/changelog/1007.fix.md
@@ -1,0 +1,1 @@
+numpy sections undetected with trailing whitespace

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -66,9 +66,11 @@ _SECTION_NAMES = "|".join(
     )
 )
 
-#: a numpy section header such as ``Returns`` underlined with dashes
+#: a numpy section header such as ``Returns`` underlined with dashes;
+#: trailing whitespace after the name is tolerated, as napoleon strips
+#: it and the underline below already allows it
 _NUMPY_SECTION = _re.compile(
-    rf"^({_SECTION_NAMES})\n\s*-{{3,}}\s*$",
+    rf"^({_SECTION_NAMES})[ \t]*\n\s*-{{3,}}\s*$",
     _re.MULTILINE | _re.IGNORECASE,
 )
 

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2832,3 +2832,33 @@ def rst(alpha) -> None:
 '''
     init_file(template)
     assert main(".") == 0
+
+
+def test_fix_numpy_section_header_with_trailing_whitespace(
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """A numpy section header survives trailing whitespace.
+
+    Problem: The numpy gate demanded the newline immediately after the
+    section name, so an invisible trailing space stopped napoleon from
+    running, while the underline below the name had always tolerated
+    the same whitespace.
+
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    # written with explicit newlines so the trailing space survives the
+    # trailing-whitespace hook
+    template = (
+        "def numpy(alpha) -> None:\n"
+        '    """Summary.\n'
+        "\n"
+        "    Parameters   \n"
+        "    ----------\n"
+        "    alpha\n"
+        "        Description of alpha.\n"
+        '    """\n'
+    )
+    init_file(template)
+    assert main(".") == 0


### PR DESCRIPTION
Closes #1007

The numpy gate required the newline to come immediately after the section
name, so an invisible trailing space stopped the docstring from ever
reaching napoleon and its documented parameters went unseen. The underline
below the name had always tolerated the same whitespace, and napoleon
strips it, so the gate was stricter than either.

`^({_SECTION_NAMES})\n` becomes `^({_SECTION_NAMES})[ \t]*\n`.

## Release note

This fix does more than remove a false positive: sections that were
previously skipped now reach napoleon, so unchanged source can report
violations it did not before.

Before:

```python
def f() -> None:
    """Summary.

    Returns
    -------
    int
        Something.
    """
```

(with trailing spaces after `Returns`) exited `0`, because the section was
never parsed. It now exits `1` with `SIG502 return-documented-for-none` —
which was always the correct result. Users upgrading may see new failures
on code they have not touched.

Staged here for the `gh release create --notes` body.