### PR TITLE
fix: sig306 undetected after an ellipsis line (#1011)

### DIFF
--- a/changelog/1011.fix.md
+++ b/changelog/1011.fix.md
@@ -1,0 +1,1 @@
+sig306 undetected after an ellipsis line

--- a/docsig/_checker.py
+++ b/docsig/_checker.py
@@ -58,9 +58,11 @@ def _last_prose_char(text: str) -> tuple[str | None, bool]:
             continue
         if para_start is None:
             para_start = stripped_ln
-        if stripped_ln.startswith(".."):
+        if stripped_ln == ".." or stripped_ln.startswith(".. "):
             # a directive or comment, e.g. `.. versionchanged:: 2.0`,
             # is not prose, and its indented content belongs to it
+            # rst explicit markup is `..` followed by whitespace, so an
+            # ellipsis starting a prose line is not a directive
             in_block = True
             continue
         if stripped_ln.endswith("::"):

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2862,3 +2862,34 @@ def test_fix_numpy_section_header_with_trailing_whitespace(
     )
     init_file(template)
     assert main(".") == 0
+
+
+def test_fix_ellipsis_line_does_not_suppress_sig306(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """A prose line starting with an ellipsis is still prose.
+
+    Problem: Any line starting with two dots was read as an rst
+    directive, but rst explicit markup is two dots followed by
+    whitespace, so a prose line starting with an ellipsis put the
+    probe in block mode and a description missing its final period
+    escaped SIG306.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def function(param: int) -> None:
+    """Summary.
+
+    :param param: The value used for
+        ... continuing thoughts with no period
+    """
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[306].ref in std.out


### PR DESCRIPTION
Closes #1011

Surfaces new violations on unchanged code: a description line starting
with `..` that is not RST explicit markup is now read as prose, so a
description that previously ended inside what looked like a directive can
be reported as missing its final period. The real-world case is a doctest
continuation (`...`) in a description with no `::` marker above it. SIG306
is still `new=True`, so these are warnings and exit codes are unchanged
until it is promoted to an error — at which point this note is worth
repeating.
