### PR TITLE
fix: pyproject resolved from the working directory (#1017)

### DIFF
--- a/changelog/1017.fix.md
+++ b/changelog/1017.fix.md
@@ -1,0 +1,1 @@
+pyproject resolved from the working directory

--- a/docsig/_config.py
+++ b/docsig/_config.py
@@ -51,47 +51,47 @@ def _split_comma(value: str) -> list[str]:
     ]
 
 
-def get_parent_that_has(file: str, start: _Path | None = None) -> _Path | None:
-    """Find the parent directory that contains the given file.
+def _common_ancestor(paths: _t.Sequence[_Path]) -> _Path:
+    # deepest path all the checked paths share, so that one config
+    # applies to the whole run no matter how many paths are given, or
+    # in what order; paths with nothing in common, such as separate
+    # windows drives, share no parts and give the working directory
+    common = []
+    for parts in zip(*(i.resolve().parts for i in paths)):
+        if len(set(parts)) != 1:
+            break
 
-    Start from the current working directory and walk up to root. If
-    no required file is found, return None.
+        common.append(parts[0])
 
-    :param file: File to find.
-    :param start: Starting director.
-    :return: Parent directory containing the file or None if not found.
-    """
-    if start is None:
-        start = _Path.cwd()
-
-    if (start / file).is_file():
-        return start
-
-    if start.parent == start:
-        return None
-
-    return get_parent_that_has(file, start.parent)
+    return _Path(*common).resolve()
 
 
-def get_config(prog: str) -> dict[str, _t.Any]:
+def get_config(prog: str, *path: _Path) -> dict[str, _t.Any]:
     """Return the program's tool-section config from pyproject.toml.
 
+    Search upwards from the common ancestor of the checked paths, and
+    return the config of the first pyproject.toml with a section for
+    the program. A pyproject.toml without one says nothing about the
+    program, e.g. a packaging only manifest, so the search continues
+    past it, whereas an empty section opts the project out.
+
     :param prog: Program name.
+    :param path: Paths being checked, whose project owns the config;
+        defaults to the current working directory.
     :return: Config dict, or empty dict if no config is found.
     """
-    # attempt to locate a pyproject.toml file if one exists in parents
-    pyproject_file = get_parent_that_has(PYPROJECT_TOML)
-    if pyproject_file is None:
-        return {}
+    # config belongs to the project the checked paths are in, which is
+    # not necessarily the project the process was started in, e.g. a
+    # package checked from the root of the monorepo containing it
+    start = _common_ancestor(path)
+    for parent in start, *start.parents:
+        pyproject_file = parent / PYPROJECT_TOML
+        if pyproject_file.is_file():
+            tool = _tomli.loads(pyproject_file.read_text()).get("tool", {})
+            if prog in tool:
+                return {k.replace("-", "_"): v for k, v in tool[prog].items()}
 
-    pyproject_file /= PYPROJECT_TOML
-    return {
-        k.replace("-", "_"): v
-        for k, v in _tomli.loads(pyproject_file.read_text())
-        .get("tool", {})
-        .get(prog, {})
-        .items()
-    }
+    return {}
 
 
 def merge_configs(
@@ -126,7 +126,10 @@ class _ArgumentParser(_argparse.ArgumentParser):
         namespace: _argparse.Namespace | None = None,
     ) -> tuple[_argparse.Namespace | None, list[str]]:
         namespace, args = super().parse_known_args(args, namespace)
-        config = get_config(_Path(self.prog).stem)
+        config = get_config(
+            _Path(self.prog).stem,
+            *getattr(namespace, "path", []),
+        )
         namespace.__dict__ = merge_configs(namespace.__dict__, config)
         return namespace, args
 

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -2975,3 +2975,85 @@ def function(cb, items, mode) -> int:
     assert E[302].ref not in std.out
     assert E[304].ref not in std.out
     assert E[404].ref not in std.out
+
+
+def test_fix_pyproject_resolved_from_the_checked_path(
+    tmp_path: Path,
+    init_pyproject_toml: FixtureInitPyprojectTomlFile,
+    main: FixtureMain,
+) -> None:
+    """Config comes from the project the checked path belongs to.
+
+    Problem: The pyproject.toml was located by walking up from the
+    current working directory, so checking a package from the root of
+    the monorepo containing it applied the root's config instead of
+    the package's, silently changing which checks ran.
+
+    :param tmp_path: Create and return the temporary directory.
+    :param init_pyproject_toml: Initialize a test pyproject.toml file.
+    :param main: Mock ``main`` function.
+    """
+    # the cwd the run starts in enables a check its project wants
+    init_pyproject_toml({"check-protected": True})
+    # the project actually being checked asks for nothing
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        "[tool.docsig]\n",
+        encoding="utf-8",
+    )
+    (project / "module.py").write_text(
+        '''def _function(param) -> None:
+    """Summary."""
+''',
+        encoding="utf-8",
+    )
+    assert main(Path("project") / "module.py", test_flake8=False) == 0
+
+
+def test_fix_pyproject_resolved_from_the_common_ancestor(
+    tmp_path: Path,
+    init_pyproject_toml: FixtureInitPyprojectTomlFile,
+    main: FixtureMain,
+) -> None:
+    """Config comes from the project all the checked paths share.
+
+    Problem: The pyproject.toml was located by walking up from the
+    current working directory, so checking packages of a monorepo from
+    outside it applied the working directory's config. Resolving from
+    the first checked path instead would have made the config depend
+    on the order the paths were given in, which for a pre-commit hook
+    is the order the files happened to be edited in.
+
+    :param tmp_path: Create and return the temporary directory.
+    :param init_pyproject_toml: Initialize a test pyproject.toml file.
+    :param main: Mock ``main`` function.
+    """
+    # the cwd the run starts in asks for nothing
+    init_pyproject_toml({})
+    project = tmp_path / "project"
+    project.mkdir()
+    # the project the checked paths share enables a check
+    (project / "pyproject.toml").write_text(
+        "[tool.docsig]\ncheck-protected = true\n",
+        encoding="utf-8",
+    )
+    modules = []
+    for name in "a", "b":
+        # neither package asks for anything on its own
+        package = project / name
+        package.mkdir()
+        (package / "pyproject.toml").write_text(
+            "[tool.docsig]\n",
+            encoding="utf-8",
+        )
+        (package / "module.py").write_text(
+            '''def _function(param) -> None:
+    """Summary."""
+''',
+            encoding="utf-8",
+        )
+        modules.append(Path("project") / name / "module.py")
+
+    assert main(*modules, test_flake8=False) == 1
+    assert main(*reversed(modules), test_flake8=False) == 1


### PR DESCRIPTION
Closes #1017

`get_config` walked up from `Path.cwd()`, so the checked path's own project was never consulted. It now searches upwards from the common ancestor of the checked paths and takes the config of the first pyproject.toml that has a `[tool.docsig]` table.

- a pyproject.toml **without** a `[tool.docsig]` table is skipped, so packaging-only manifests in a monorepo don't shadow the root config
- an **empty** `[tool.docsig]` table stops the search, so a project can opt out
- the search starts at the **common ancestor** of every checked path, so the config doesn't depend on the order paths are given in — which for a pre-commit hook is the order files happened to be edited in

This brings config resolution in line with `_files.py`, which already resolves gitignore patterns from the repo each checked path belongs to. It also fixes the neovim plugin, which runs docsig with `cwd` set to the workspace root while checking a buffer that may live in a subproject.

`get_parent_that_has` is removed — its "nearest ancestor containing a file" contract no longer describes the search, and `get_config` was its only caller.

Two regression tests, both verified to fail without the fix.
