### PR TITLE
fix: inline directive dropped before intervening lines (#1019)

### DIFF
--- a/changelog/1019.fix.md
+++ b/changelog/1019.fix.md
@@ -1,0 +1,1 @@
+inline directive dropped before intervening lines

--- a/docsig/_directives.py
+++ b/docsig/_directives.py
@@ -126,8 +126,10 @@ class _Scanner:
     * 'next' scope - a module directive flagged 'next' applies until
         the following statement, then module scope is restored from a
         snapshot taken at the directive
-    * inline scope - a directive on a code line, applying to that line
-        and the one that follows
+    * inline scope - an indented directive, applying from its own line
+        until the statement it annotates ends; blank lines and further
+        comments in between do not end that reach, and consecutive
+        directives stack rather than replacing one another
 
     :param messages: Initial list of messages to disable.
     """
@@ -184,13 +186,25 @@ class _Scanner:
             self._comments, self._messages = self._next_scope
             self._next_scope = None
 
-        scope = self._take_pending_inline(lineno) or scope
+        # an indented directive reaches the statement it annotates
+        # across any blank or comment lines between the two
+        if self._pending_inline is not None:
+            _, pending_comments, pending_messages = self._pending_inline
+            scope = Comments(pending_comments), _Messages(pending_messages)
 
         # the first entry recorded for a line wins, unless an inline
         # directive already claimed the line in _apply
         self._directives.setdefault(lineno, scope)
+        self._end_pending_inline(lineno, token.type)
 
     def _apply(self, comment: Comment, lineno: int, scope: _Scope) -> _Scope:
+        if not comment.ismodule and self._pending_inline is not None:
+            # stack onto an indented directive that is still waiting
+            # for its statement, so neither directive is lost, the way
+            # module directives already accumulate
+            _, pending_comments, pending_messages = self._pending_inline
+            scope = Comments(pending_comments), _Messages(pending_messages)
+
         comments, messages = scope
         comments.append(comment)
         if comment.disable:
@@ -227,18 +241,16 @@ class _Scanner:
 
         return comments, messages
 
-    def _take_pending_inline(self, lineno: int) -> _Scope | None:
-        # inherit a deferred inline scope on the first line after the
-        # comment (e.g. an indented def on the following line)
-        if self._pending_inline is None:
-            return None
-
-        pending_lineno, comments, messages = self._pending_inline
-        if lineno <= pending_lineno:
-            return None
-
-        self._pending_inline = None
-        return comments, messages
+    def _end_pending_inline(self, lineno: int, kind: int) -> None:
+        # the end of a statement on a line after the directive ends its
+        # reach; a directive written on the code line itself ends at
+        # the following statement instead, so its own line is excluded
+        if (
+            self._pending_inline is not None
+            and kind == _tokenize.NEWLINE
+            and lineno > self._pending_inline[0]
+        ):
+            self._pending_inline = None
 
 
 class Directives(dict[int, _Scope]):

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -3057,3 +3057,55 @@ def test_fix_pyproject_resolved_from_the_common_ancestor(
 
     assert main(*modules, test_flake8=False) == 1
     assert main(*reversed(modules), test_flake8=False) == 1
+
+
+def test_fix_indented_directive_reach_over_intervening_lines(
+    capsys: pytest.CaptureFixture,
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """An indented directive reaches the statement it annotates.
+
+    Problem: An indented directive was deferred to the single line
+    following it and replaced any directive already deferred, so a
+    blank or comment line before the def dropped it, and stacked
+    directives lost all but the last, while the same directives at
+    module level applied correctly.
+
+    :param capsys: Capture sys out.
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+class Klass:
+    """Summary."""
+
+    # docsig: disable-next=duplicate-params-found,params-out-of-order
+    # docsig: disable-next=confirm-return-needed
+    def method_1(self, param1, param2, param3):
+        """Summary.
+
+        :param param1: Description of param1.
+        :param param3: Description of param3.
+        :param param2: Description of param2.
+        :param param2: Description of param2.
+        """
+
+    # docsig: disable-next=params-missing
+    # a comment explaining why the check is disabled
+
+    def method_2(self, param) -> None:
+        """Summary."""
+
+    def method_3(self, param) -> None:
+        """Summary."""
+'''
+    init_file(template)
+    main(".")
+    std = capsys.readouterr()
+    assert E[201].ref not in std.out
+    assert E[402].ref not in std.out
+    assert "method_2" not in std.out
+    # the directives must not reach past the statement they annotate
+    assert E[203].ref in std.out
+    assert "method_3" in std.out


### PR DESCRIPTION
Closes #1019

An indented `# docsig: disable-next` directive was deferred to the
single line that followed it, so a blank line or an explanatory comment
between the directive and the `def` dropped it. The same directive at
module level applied correctly.

The deferred scope now reaches until the statement it annotates ends,
so intervening blank and comment lines no longer break it, and it still
stops at that statement rather than leaking into the next one.

Consecutive indented directives shared the root cause: each replaced
the one still waiting instead of accumulating, so all but the last were
lost. They now stack, the way module directives already did.

The change only ever widens a directive's reach, so no previously
passing code starts reporting violations.