### PR TITLE
fix: message list kwargs rejected by type checkers (#1021)

### DIFF
--- a/changelog/1021.fix.md
+++ b/changelog/1021.fix.md
@@ -1,0 +1,1 @@
+message list kwargs rejected by type checkers

--- a/docsig/_core.py
+++ b/docsig/_core.py
@@ -7,6 +7,7 @@ Entry point and orchestration for running docstring/signature checks.
 
 import logging as _logging
 import sys as _sys
+import typing as _t
 import warnings as _warnings
 from pathlib import Path as _Path
 from pprint import pformat as _pformat
@@ -113,8 +114,8 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
     ignore_typechecker: bool = False,  # deprecated
     no_ansi: bool = False,
     verbose: bool = False,
-    target: _Messages | None = None,
-    disable: _Messages | None = None,
+    target: list[str] | None = None,
+    disable: list[str] | None = None,
     exclude: str | list[str] | None = None,
     excludes: list[str] | None = None,
 ) -> int:
@@ -154,10 +155,12 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
     :param excludes: Files or dirs to exclude from checks.
     :return: Exit code (non-zero if any check failed).
     """
-    disable = disable or _Messages()
+    # the annotations describe the caller's interface; _parse_msgs has
+    # already converted these to Messages by the time they land
+    disabled = _t.cast("_Messages | None", disable) or _Messages()
     handle_deprecations(
         ignore_typechecker,
-        disable,
+        disabled,
         [
             _E[501],
             _E[502],
@@ -204,8 +207,8 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
         filters=filters,
         no_ansi=no_ansi,
         verbose=verbose,
-        target=target or _Messages(),
-        disable=disable,
+        target=_t.cast("_Messages | None", target) or _Messages(),
+        disable=disabled,
     )
     setup_logger(config.verbose)
     _logging.getLogger(__package__).debug(_pformat(config))

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -7,9 +7,12 @@ tests.fix_test
 import io
 import json
 import pickle
+import typing as t
 from pathlib import Path
 
 import pytest
+
+from docsig import docsig
 
 # noinspection PyProtectedMember
 from docsig._config import _ArgumentParser, _split_comma, build_parser
@@ -3109,3 +3112,17 @@ class Klass:
     # the directives must not reach past the statement they annotate
     assert E[203].ref in std.out
     assert "method_3" in std.out
+
+
+def test_fix_message_list_kwargs_rejected_by_type_checkers() -> None:
+    """Annotate target and disable as the string lists they accept.
+
+    The entry point advertised ``Messages`` for both kwargs, but
+    ``parse_msgs`` builds them from codes, so the documented calls
+    passing a list of string refs were rejected by a type checker, while
+    the annotated ``Messages`` form failed at runtime as unknown
+    options.
+    """
+    hints = t.get_type_hints(docsig)
+    assert hints["target"] == list[str] | None
+    assert hints["disable"] == list[str] | None


### PR DESCRIPTION
Closes #1021

`docsig()` annotated `target` and `disable` as `Messages | None`, but `@parse_msgs` builds them with `E.from_codes(...)` and `from_ref` matches on `ref`/`symbolic` — strings. The annotation was backwards rather than merely loose: the documented call was rejected by type checkers, and the annotated form failed at runtime with `unknown option to disable`.

Annotate both as `list[str] | None` and cast at the two use sites, where `parse_msgs` has already converted them. `disabled` is a new local rather than a rebind of `disable`, so the deprecation shim still receives `Messages` without a type error.

No behaviour change — `Messages` is not exported from the package root and passing one never worked, so no working call is affected.

The regression test asserts the annotations via `get_type_hints`, since an annotation-only change has no runtime behaviour to observe. Verified red against master's `_core.py` (`assert docsig.messages.Messages | None == (list[str] | None)`) and green with the fix.