### PR TITLE
fix: numpy sections undetected with short underlines (#1035)

### DIFF
--- a/changelog/1035.fix.md
+++ b/changelog/1035.fix.md
@@ -1,0 +1,1 @@
+numpy sections undetected with short underlines

--- a/docsig/_stub.py
+++ b/docsig/_stub.py
@@ -74,7 +74,7 @@ _SECTION_NAMES = "|".join(
 #: trailing whitespace after the name is tolerated, as napoleon strips
 #: it and the underline below already allows it
 _NUMPY_SECTION = _re.compile(
-    rf"^({_SECTION_NAMES})[ \t]*\n\s*-{{3,}}\s*$",
+    rf"^({_SECTION_NAMES})[ \t]*\n\s*-{{2,}}\s*$",
     _re.MULTILINE | _re.IGNORECASE,
 )
 

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -3126,3 +3126,30 @@ def test_fix_message_list_kwargs_rejected_by_type_checkers() -> None:
     hints = t.get_type_hints(docsig)
     assert hints["target"] == list[str] | None
     assert hints["disable"] == list[str] | None
+
+
+def test_fix_numpy_section_header_with_short_underline(
+    init_file: FixtureInitFile,
+    main: FixtureMain,
+) -> None:
+    """A numpy section header underlined with two dashes is a section.
+
+    Problem: The numpy gate demanded three dashes under the section
+    name, while napoleon accepts two, so a two dash underline stopped
+    napoleon from running and the params vanished.
+
+    :param init_file: Initialize a test file.
+    :param main: Mock ``main`` function.
+    """
+    template = '''
+def numpy(alpha) -> None:
+    """Summary.
+
+    Parameters
+    --
+    alpha
+        Description of alpha.
+    """
+'''
+    init_file(template)
+    assert main(".") == 0


### PR DESCRIPTION
Closes #1035

The numpy gate in `docsig/_stub.py` required three or more dashes under a section name (`-{3,}`), while napoleon accepts two. A two-dash underline therefore never reached `NumpyDocstring`, the parameters were never parsed out of the docstring, and documented parameters came back as SIG203 `params-missing`.

Relax the gate to `-{2,}` so it matches what napoleon will actually convert.