### PR TITLE
fix: empty string treated as missing input (#1037)

### DIFF
--- a/changelog/1037.fix.md
+++ b/changelog/1037.fix.md
@@ -1,0 +1,1 @@
+empty string treated as missing input

--- a/docsig/_core.py
+++ b/docsig/_core.py
@@ -217,7 +217,7 @@ def docsig(  # pylint: disable=too-many-locals,too-many-arguments
         # noinspection PyNoneFunctionAssignment
         return int(bool(_print_checks()))  # type: ignore
 
-    if string:
+    if string is not None:
         return _check_string(string, config)
 
     return _check_files(path, config)

--- a/docsig/_decorators.py
+++ b/docsig/_decorators.py
@@ -41,7 +41,7 @@ def _validation_errors(
     kwargs: dict[str, _t.Any],
 ) -> list[str]:
     errors = []
-    if not args and not kwargs.get("string"):
+    if not args and kwargs.get("string") is None:
         errors.append(
             "the following arguments are required: path(s) or string",
         )

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -3153,3 +3153,19 @@ def numpy(alpha) -> None:
 '''
     init_file(template)
     assert main(".") == 0
+
+
+def test_fix_empty_string_is_an_empty_module(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """An empty string is checked as an empty module, not rejected.
+
+    Problem: The guard for a missing string argument tested truthiness
+    rather than presence, so docsig(string="") was reported as a usage
+    error (exit status 2) while checking an empty file passed with 0.
+
+    :param capsys: Capture sys out.
+    """
+    assert docsig(string="") == 0
+    std = capsys.readouterr()
+    assert not std.err


### PR DESCRIPTION
Closes #1037

`docsig(string="")` was rejected as a usage error (exit status 2) because the missing-string guard tested truthiness rather than presence, while checking an empty file passed with 0. An empty string is a valid empty module.

Tests `is None` at the guard in `_decorators.py`, and at the dispatch in `_core.py` so a provided empty string is checked as a string rather than falling through to file discovery.