### PR TITLE
ci(neovim-plugin): harden the mirror publish against a lost deploy key

### DIFF
--- a/.github/workflows/build-neovim-plugin.yaml
+++ b/.github/workflows/build-neovim-plugin.yaml
@@ -99,8 +99,22 @@ jobs:
           printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/docsig_nvim
           chmod 600 ~/.ssh/docsig_nvim
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/docsig_nvim"
+          # identities-only stops ssh falling back to another identity the
+          # runner happens to carry, so a rejection is always this key
+          ssh_command="ssh -o IdentitiesOnly=yes -i ~/.ssh/docsig_nvim"
+          export GIT_SSH_COMMAND="${ssh_command}"
           echo "GIT_SSH_COMMAND=${GIT_SSH_COMMAND}" >> "$GITHUB_ENV"
+          # the deploy key living on the mirror can be removed without
+          # anything here changing, and git reports that as a bare
+          # permission denied against a public repository that needs no
+          # permission to read, so name it before the rest of the job runs
+          if ! $ssh_command -T git@github.com 2>&1 \
+              | grep -q 'successfully authenticated'; then
+            echo "::error::DOCSIG_NVIM_DEPLOY_KEY is not registered on \
+          jshwi/docsig.nvim; add its public half as a deploy key with \
+          write access"
+            exit 1
+          fi
           git clone git@github.com:jshwi/docsig.nvim mirror
         env:
           DEPLOY_KEY: ${{ secrets.DOCSIG_NVIM_DEPLOY_KEY }}

--- a/.github/workflows/check-mirror-credential.yaml
+++ b/.github/workflows/check-mirror-credential.yaml
@@ -1,0 +1,41 @@
+---
+name: Check Mirror Credential
+on:
+  workflow_dispatch:
+  # the key this exercises lives on jshwi/docsig.nvim, where it can be
+  # removed without anything in this repository changing, so the only
+  # way to know it is alive is to use it; do that on a schedule and on
+  # demand before a release, rather than discovering it from a red
+  # publish job on a tag that has already been pushed
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: mirror-credential
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe Mirror Write Access
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/docsig_nvim
+          chmod 600 ~/.ssh/docsig_nvim
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          # receive-pack advertises the mirror's refs and exits on a
+          # closed stdin, so this reports the write access an actual
+          # push would need without pushing anything; a read only key
+          # authenticates but is refused here, same as it would be at
+          # the end of a publish
+          if ! ssh -o IdentitiesOnly=yes -i ~/.ssh/docsig_nvim \
+              git@github.com "git-receive-pack 'jshwi/docsig.nvim.git'" \
+              </dev/null >/dev/null; then
+            echo "::error::DOCSIG_NVIM_DEPLOY_KEY cannot write to \
+          jshwi/docsig.nvim; register its public half there as a deploy \
+          key with write access, before releasing"
+            exit 1
+          fi
+        env:
+          DEPLOY_KEY: ${{ secrets.DOCSIG_NVIM_DEPLOY_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,12 @@ build/site-packages/$(VERSION): build/requirements.txt
 	@$(RUN) pip install . --no-deps --target $(@D)
 	@touch $@
 
+# a fresh install stamps site-packages with the install time, so without
+# a fixed timestamp every build differs and the mirror commits the
+# bundle again whether or not it changed
 build/docsig.pyz: build/site-packages/$(VERSION)
 	@$(RUN) shiv \
+		--reproducible \
 		--site-packages $(<D) \
 		--entry-point docsig.__main__:main \
 		--output-file $@


### PR DESCRIPTION
Two independent problems the `v0.93.1` mirror failure exposed.

### `chore(make)` — the bundle was never reproducible

`shiv` stamps zip entries with the mtimes of `build/site-packages/`, which a
fresh `pip install --target` sets to the install time. Two installs from the
same locked `requirements.txt`, bundled with the current recipe:

```
f4c60f6b…  install A
343c3e1f…  install B     differ
```

With `--reproducible`, across those same two separate installs:

```
ffc99bac…  install A
ffc99bac…  install B     identical
```

The publish job already guards on `git diff --cached --quiet`, but that guard
could never fire, so every sync rewrote a 713 KB binary into the mirror whether
or not it changed — `7db1e257` and `dbb2ffee` are the same Lua fix landed
11 minutes apart, and both carry a fresh `resources/docsig.pyz`.

### `ci(neovim-plugin)` — a removed deploy key was unreadable from the log

The deploy key on `jshwi/docsig.nvim` was deleted between 2026-08-03 and
2026-08-05 with nothing in this repository changing (the secret's `created_at`
still equals its `updated_at`). Run 31012121719 reported only:

```
git@github.com: Permission denied (publickey).
```

which reads as a permissions problem against a repository that is public and
needs no permission to read. The real cause is that the key authenticates as
nobody. An `ssh -T` preflight now names it before the job spends any further
time, and `IdentitiesOnly=yes` stops ssh from falling back to another identity
and masking which key is in play.